### PR TITLE
docs: update documentation for 2.0.0

### DIFF
--- a/MODERNIZE.md
+++ b/MODERNIZE.md
@@ -70,7 +70,7 @@ This document tracked the modernization of zebra_day from 0.5.0 to 2.0.0.
 pytest -v                           # Run tests
 pytest --cov=zebra_day              # Run tests with coverage
 ruff check zebra_day tests          # Lint
-black --check zebra_day tests       # Format check
+ruff format --check zebra_day tests # Format check
 mypy zebra_day                      # Type check
 
 # CLI

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pytest -v
 
 # Run Linting (requires pip install -e ".[lint]")
 ruff check zebra_day tests
-black --check zebra_day tests
+ruff format --check zebra_day tests
 mypy zebra_day --ignore-missing-imports
 
 # CLI Commands
@@ -433,15 +433,14 @@ zlab = zdpm.zpl()
 
 zlab.probe_zebra_printers_add_to_printers_json('192.168.1')  # REPLACE the IP stub with the correct value for your network. This may take a few min to run.  !! This command is not required if you've sucessuflly run the quickstart already, also, won't hurt.
 
-print(zlab.printers)  # This should print out the json dict of all detected zebra printers. An empty dict, {}, is a failure of autodetection, and manual creation of the json file may be needed. If successful, the lab name assigned is 'scan-results', this may be edited latter.
+print(zlab.printers)  # This should print out the json dict of all detected zebra printers. An empty dict, {}, is a failure of autodetection, and manual creation of the json file may be needed. If successful, the lab name assigned is 'default', this may be edited later.
 
-# The json will loook something like this
-## {'labs': {'scan-results': {'192.168.1.7': {'ip_address': '192.168.1.7', 'label_zpl_styles': ['test_2inX1in'], 'print_method': 'unk'}}}
-##               'lab' name     'printer' name(can be edited latter)                              label_zpl_style
+# The json will look something like this (v2.0.0 schema with nested printers)
+## {'schema_version': '2.0.0', 'labs': {'default': {'lab_name': 'Default', 'printers': {'192.168.1.7': {'ip_address': '192.168.1.7', ...}}}}}
 
-# Assuming a printer was detected, send a test print request.  Using the 'lab', 'printer' and 'label_zpl_style' above (you'd have your own IP/Name, other values should remain the same for now.  There are multiple label ZPL formats available, the test_2inX1in is for quick testing & only formats in the two UID values specified.
+# Assuming a printer was detected, send a test print request. Using the 'lab', 'printer' and 'label_zpl_style' above (you'd have your own IP/Name, other values should remain the same for now. There are multiple label ZPL formats available, the test_2inX1in is for quick testing & only formats in the two UID values specified.
 
-zlab.print_zpl(lab='scan-results', printer_name='192.168.1.7', label_zpl_style='test_2inX1in', uid_barcode="123aUID")
+zlab.print_zpl(lab='default', printer_name='192.168.1.7', label_zpl_style='test_2inX1in', uid_barcode="123aUID")
 # ZPL code sent successfully to the printer!
 # Out[13]: '^XA\n^FO235,20\n^BY1\n^B3N,N,40,N,N\n^FD123aUID^FS\n^FO235,70\n^ADN,30,20\n^FD123aUID^FS\n^FO235,115\n^ADN,25,12\n^FDalt_a^FS\n^FO235,145\n^ADN,25,12\n^FDalt_b^FS\n^FO70,180\n^FO235,170\n^ADN,30,20\n^FDalt_c^FS\n^FO490,180\n^ADN,25,12\n^FDalt_d^FS\n^XZ'
 ```
@@ -519,7 +518,7 @@ The modern UI offers:
 ### Print via HTTP API
 
 ```http
-http://YOUR.HOST.IP.ADDR:8118/_print_label?lab=scan-results&printer=192.168.1.7&label_zpl_style=test_2inX1in&uid_barcode=123aUID
+http://YOUR.HOST.IP.ADDR:8118/_print_label?lab=default&printer=192.168.1.7&label_zpl_style=test_2inX1in&uid_barcode=123aUID
 ```
 
 * See the [Web UI Guide](zebra_day/docs/zebra_day_ui_guide.md) for full details.
@@ -669,16 +668,16 @@ And looks like:
 #### Sending Label Print Requests
 ##### from a web browser on a different network
 
-`https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode=UID33344455&alt_a=altTEXTAA&alt_b=altTEXTBB&alt_c=altTEXTCC&alt_d=&alt_e=&alt_f=&lab=scan-results&printer=192.168.1.20&printer_ip=192.168.1.20&label_zpl_style=tube_2inX1in`
+`https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode=UID33344455&alt_a=altTEXTAA&alt_b=altTEXTBB&alt_c=altTEXTCC&alt_d=&alt_e=&alt_f=&lab=default&printer=192.168.1.20&printer_ip=192.168.1.20&label_zpl_style=tube_2inX1in`
 
 ##### Using wget from a shell on a machine outside your local network
 ```bash
-wget "https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode=UID33344455&alt_a=altTEXTAA&alt_b=altTEXTBB&alt_c=altTEXTCC&alt_d=&alt_e=&alt_f=&lab=scan-results&printer=192.168.1.20&printer_ip=192.168.1.20&label_zpl_style=tube_2inX1in"
+wget "https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode=UID33344455&alt_a=altTEXTAA&alt_b=altTEXTBB&alt_c=altTEXTCC&alt_d=&alt_e=&alt_f=&lab=default&printer=192.168.1.20&printer_ip=192.168.1.20&label_zpl_style=tube_2inX1in"
 ```
 
 ### From SalesForce
 
- * There are several ways to do this, but they all boil down to somehow formulating a URL for each print request, ie: `https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode=UID33344455&lab=scan-results&printer=192.168.1.20&label_zpl_style=tube_2inX1in`, and hitting the URL via Apex, Flow, etc.
+ * There are several ways to do this, but they all boil down to somehow formulating a URL for each print request, ie: `https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode=UID33344455&lab=default&printer=192.168.1.20&label_zpl_style=tube_2inX1in`, and hitting the URL via Apex, Flow, etc.
    * To send a print request, you will need to know the API url, and the `lab`, `printer_name`, and `label_zpl_style` you wish to print the salesforce `Name` aka `UID` as a label.  This example explains how to pass just one variable to print from salesforce, adding additional metadata to print involves adding additional params to the url being constructed.
 
 
@@ -733,7 +732,7 @@ Next, create a flow which uses this Apex Class.
 * Choose `Actions and Related Records`, and check the box at the bottom of the page to `Include a Run Asynchronously path...`
   * upon clicking this box, the graphic representation of the flow to the left of the page will now have 2 branches at the bottom of the flow rule, one `Run Immediately` and one `Run Asynchronously`.  The `Run Immediately` branch was throwing errors, so I removed it to debug at a latter date.
   * Click the node just below the `Run Asynch` oval. Add an `Action`. Select the `Make HTTP Request` we created via the Apex Class above.  Give it a `Label`, let the API Name auto generate.
-  * In the `Endpoint URL` field, enter the url `https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode={!$Record.Name}&lab=scan-results&printer=!!YOURPRINTERIP!!&label_zpl_style=tube_2inX1in`, where Record.Name will be replaced with the Object.Name from the object triggering the flow.  Replace !!YOURPRINTERIP!! with one of the printer IPs zebra_day detected above.  If you are using the auto-generated zebra printers config json file, you may leave `scan-results` as the value for `lab=` as this will be the default name given when zebra_day autodetects printers.
+  * In the `Endpoint URL` field, enter the url `https://dfbf-23-93-175-197.ngrok-free.app/_print_label?uid_barcode={!$Record.Name}&lab=default&printer=!!YOURPRINTERIP!!&label_zpl_style=tube_2inX1in`, where Record.Name will be replaced with the Object.Name from the object triggering the flow.  Replace !!YOURPRINTERIP!! with one of the printer IPs zebra_day detected above.  If you are using the auto-generated zebra printers config json file, you may leave `default` as the value for `lab=` as this will be the default name given when zebra_day autodetects printers.
   * add the same HTTPrequest action to the node just below `Run Immediately`.
   * click `Save` in the upper right corner of the page. Give it a name
   * Click `Debug Again`, run the `Run Immediately` branch first. This will fail.

--- a/scripts/capture_screenshots.py
+++ b/scripts/capture_screenshots.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Capture screenshots of the zebra_day web UI using Playwright.
+
+Usage:
+    # Install playwright first
+    pip install playwright
+    playwright install chromium
+
+    # Start the zebra_day server
+    zday gui start
+
+    # Run this script
+    python scripts/capture_screenshots.py
+
+    # Screenshots will be saved to zebra_day/imgs/
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    print("Error: playwright not installed. Run:")
+    print("  pip install playwright")
+    print("  playwright install chromium")
+    sys.exit(1)
+
+
+# Pages to capture
+PAGES = [
+    {"name": "dashboard", "path": "/", "wait_for": ".stat-card"},
+    {"name": "printers", "path": "/printers", "wait_for": ".card"},
+    {"name": "print_request", "path": "/print", "wait_for": "form"},
+    {"name": "templates", "path": "/templates", "wait_for": ".card"},
+    {"name": "config", "path": "/config", "wait_for": ".card"},
+    {"name": "api_docs", "path": "/docs", "wait_for": ".swagger-ui"},
+]
+
+
+def capture_screenshots(
+    base_url: str = "https://localhost:8118",
+    output_dir: Path = Path("zebra_day/imgs"),
+    viewport_width: int = 1280,
+    viewport_height: int = 800,
+    prefix: str = "ui_",
+) -> list[Path]:
+    """Capture screenshots of all UI pages.
+
+    Args:
+        base_url: The base URL of the zebra_day server
+        output_dir: Directory to save screenshots
+        viewport_width: Browser viewport width
+        viewport_height: Browser viewport height
+        prefix: Prefix for screenshot filenames
+
+    Returns:
+        List of paths to saved screenshots
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    saved_files: list[Path] = []
+
+    with sync_playwright() as p:
+        # Launch browser - ignore HTTPS errors for local dev certs
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            viewport={"width": viewport_width, "height": viewport_height},
+            ignore_https_errors=True,
+        )
+        page = context.new_page()
+
+        for page_info in PAGES:
+            url = f"{base_url}{page_info['path']}"
+            output_path = output_dir / f"{prefix}{page_info['name']}.png"
+
+            print(f"Capturing {page_info['name']}... ", end="", flush=True)
+
+            try:
+                page.goto(url, wait_until="networkidle", timeout=30000)
+
+                # Wait for key element to be visible
+                if page_info.get("wait_for"):
+                    try:
+                        page.wait_for_selector(page_info["wait_for"], timeout=5000, state="visible")
+                    except Exception:
+                        pass  # Continue even if element not found
+
+                # Small delay for any animations
+                page.wait_for_timeout(500)
+
+                # Capture screenshot
+                page.screenshot(path=str(output_path), full_page=False)
+                saved_files.append(output_path)
+                print(f"saved to {output_path}")
+
+            except Exception as e:
+                print(f"FAILED: {e}")
+
+        browser.close()
+
+    return saved_files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Capture screenshots of zebra_day web UI")
+    parser.add_argument(
+        "--url",
+        default="https://localhost:8118",
+        help="Base URL of zebra_day server (default: https://localhost:8118)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("zebra_day/imgs"),
+        help="Output directory for screenshots (default: zebra_day/imgs)",
+    )
+    parser.add_argument("--width", type=int, default=1280, help="Viewport width (default: 1280)")
+    parser.add_argument("--height", type=int, default=800, help="Viewport height (default: 800)")
+    parser.add_argument("--prefix", default="ui_", help="Filename prefix (default: ui_)")
+
+    args = parser.parse_args()
+
+    print(f"Capturing screenshots from {args.url}")
+    print(f"Output directory: {args.output_dir}")
+    print()
+
+    saved = capture_screenshots(
+        base_url=args.url,
+        output_dir=args.output_dir,
+        viewport_width=args.width,
+        viewport_height=args.height,
+        prefix=args.prefix,
+    )
+
+    print(f"\nCaptured {len(saved)} screenshots")
+    return 0 if saved else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zebra_day/docs/programatic_guide.md
+++ b/zebra_day/docs/programatic_guide.md
@@ -9,14 +9,13 @@ zlab = zdpm.zpl()
 
 zlab.probe_zebra_printers_add_to_printers_json('192.168.1')  # REPLACE the IP stub with the correct value for your network. This may take a few min to run.  !! This command is not required if you've sucessuflly run the quickstart already, also, won't hurt.
 
-print(zlab.printers)  # This should print out the json dict of all detected zebra printers. An empty dict, {}, is a failure of autodetection, and manual creation of the json file may be needed. If successful, the lab name assigned is 'scan-results', this may be edited latter.
-# The json will loook something like this
-## {'labs': {'scan-results': {'192.168.1.7': {'ip_address': '192.168.1.7', 'label_zpl_styles': ['test_2inX1in'], 'print_method': 'unk'}}}
-##               'lab' name     'printer' name(can be edited latter)                              label_zpl_style
+print(zlab.printers)  # This should print out the json dict of all detected zebra printers. An empty dict, {}, is a failure of autodetection, and manual creation of the json file may be needed. If successful, the lab name assigned is 'default', this may be edited later.
+# The json will look something like this (v2.0.0 schema with nested printers)
+## {'schema_version': '2.0.0', 'labs': {'default': {'lab_name': 'Default', 'printers': {'192.168.1.7': {'ip_address': '192.168.1.7', ...}}}}}
 
-# Assuming a printer was detected, send a test print request.  Using the 'lab', 'printer' and 'label_zpl_style' above (you'd have your own IP/Name, other values should remain the same for now.  There are multiple label ZPL formats available, the test_2inX1in is for quick testing & only formats in the two UID values specified.
+# Assuming a printer was detected, send a test print request. Using the 'lab', 'printer' and 'label_zpl_style' above (you'd have your own IP/Name, other values should remain the same for now. There are multiple label ZPL formats available, the test_2inX1in is for quick testing & only formats in the two UID values specified.
 
-zlab.print_zpl(lab='scan-results', printer_name='192.168.1.7', label_zpl_style='test_2inX1in', uid_barcode="123aUID")
+zlab.print_zpl(lab='default', printer_name='192.168.1.7', label_zpl_style='test_2inX1in', uid_barcode="123aUID")
 # ZPL code sent successfully to the printer!
 # Out[13]: '^XA\n^FO235,20\n^BY1\n^B3N,N,40,N,N\n^FD123aUID^FS\n^FO235,70\n^ADN,30,20\n^FD123aUID^FS\n^FO235,115\n^ADN,25,12\n^FDalt_a^FS\n^FO235,145\n^ADN,25,12\n^FDalt_b^FS\n^FO70,180\n^FO235,170\n^ADN,30,20\n^FDalt_c^FS\n^FO490,180\n^ADN,25,12\n^FDalt_d^FS\n^XZ'
 ```
@@ -91,23 +90,10 @@ This is the file which describes the printer fleet. It may be manually edited or
 {
     "schema_version": "2.0.0",
     "labs": {
-        "scan-results": {
-            "lab_name": "Scan Results",
+        "default": {
+            "lab_name": "Default",
             "available_locations": ["Bench A", "Bench B"],
             "printers": {
-                "Download-Label-png": {
-                    "ip_address": "dl_png",
-                    "printer_name": "Download Label as PNG",
-                    "lab_location": null,
-                    "manufacturer": "virtual",
-                    "model": "na",
-                    "serial": "na",
-                    "label_zpl_styles": ["tube_2inX1in"],
-                    "default_label_style": "tube_2inX1in",
-                    "print_method": "generate png",
-                    "arp_data": "",
-                    "notes": ""
-                },
                 "192.168.1.7": {
                     "ip_address": "192.168.1.7",
                     "printer_name": "Main Lab Printer",
@@ -133,7 +119,37 @@ This is the file which describes the printer fleet. It may be manually edited or
 - Added `printer_name`, `lab_location`, `manufacturer`, `default_label_style`, `notes` at printer level
 - Added `schema_version` at root level
 
-The `lab` key in this example is `scan-results`, which is the lab name assigned when autodetect runs. These names are editable via the GUI. Printers are nested under the `printers` key within each lab.
+The `lab` key in this example is `default`, which is the lab name assigned when autodetect runs. These names are editable via the GUI. Printers are nested under the `printers` key within each lab.
+
+### Rendering ZPL to PNG (without printing)
+
+To generate a PNG preview of a label without sending to a printer, use the `/api/v1/render` endpoint:
+
+```bash
+# Render using a template
+curl -X POST "https://localhost:8118/api/v1/render" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "template_name": "tube_2inX1in",
+    "uid_barcode": "SAMPLE123",
+    "alt_a": "Field A",
+    "alt_b": "Field B"
+  }' \
+  --output label.png
+
+# Render raw ZPL content
+curl -X POST "https://localhost:8118/api/v1/render" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "zpl_content": "^XA^FO50,50^ADN,36,20^FDHello World^FS^XZ"
+  }' \
+  --output label.png
+```
+
+The render endpoint returns a PNG image directly. This is useful for:
+- Previewing labels before printing
+- Generating label images for documentation
+- Testing ZPL templates without physical printers
 
 ### ZPL Template Files
 These are template files for various different label styles. These may be manually edited (but its a nicer expereience using the UI)

--- a/zebra_day/docs/zebra_day_ui_guide.md
+++ b/zebra_day/docs/zebra_day_ui_guide.md
@@ -71,8 +71,98 @@ zebra_day 2.0.0+ features a modern, responsive web interface with HTTPS support:
 <img width="909" alt="print_success" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/5da259f3-0ed4-4c18-953d-c091690e703c">
 
 <img width="411" alt="zplab" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/024a49b8-b86f-4950-abe4-93eedc62101c">
-<hr>
-<hr>
+
+---
+
+## API Reference (curl examples)
+
+All API endpoints are documented at `/docs` (Swagger UI) and `/redoc`. Here are common operations:
+
+### Health Checks
+
+```bash
+# Basic health check
+curl https://localhost:8118/healthz
+
+# Readiness check (printer manager initialized)
+curl https://localhost:8118/readyz
+```
+
+### Printer Operations
+
+```bash
+# List all printers
+curl https://localhost:8118/api/v1/printers
+
+# Get printer status
+curl "https://localhost:8118/api/v1/printers/default/192.168.1.7/status"
+
+# Scan for new printers
+curl -X POST "https://localhost:8118/api/v1/printers/scan?ip_stub=192.168.1"
+```
+
+### Print Labels
+
+```bash
+# Print a label using a template
+curl -X POST "https://localhost:8118/api/v1/print" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "lab": "default",
+    "printer_name": "192.168.1.7",
+    "label_zpl_style": "tube_2inX1in",
+    "uid_barcode": "SAMPLE123",
+    "alt_a": "Field A",
+    "alt_b": "Field B"
+  }'
+
+# Legacy query-string format (still supported)
+curl "https://localhost:8118/_print_label?lab=default&printer=192.168.1.7&label_zpl_style=tube_2inX1in&uid_barcode=SAMPLE123"
+```
+
+### Render Labels (PNG preview without printing)
+
+```bash
+# Render using a template
+curl -X POST "https://localhost:8118/api/v1/render" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "template_name": "tube_2inX1in",
+    "uid_barcode": "SAMPLE123",
+    "alt_a": "Field A"
+  }' \
+  --output label.png
+
+# Render raw ZPL
+curl -X POST "https://localhost:8118/api/v1/render" \
+  -H "Content-Type: application/json" \
+  -d '{"zpl_content": "^XA^FO50,50^ADN,36,20^FDHello^FS^XZ"}' \
+  --output label.png
+```
+
+### Template Operations
+
+```bash
+# List all templates
+curl https://localhost:8118/api/v1/templates
+
+# Get template content
+curl https://localhost:8118/api/v1/templates/tube_2inX1in
+```
+
+### Configuration
+
+```bash
+# Get current configuration
+curl https://localhost:8118/api/v1/config
+
+# Update configuration (PATCH)
+curl -X PATCH "https://localhost:8118/api/v1/config" \
+  -H "Content-Type: application/json" \
+  -d '{"labs": {"default": {"lab_name": "Main Lab"}}}'
+```
+
+---
 
 ## Zebra Printer Web Admin UI
 Often, I find these pages valuable in triaging a poorly behaving printer.  I compare a well behaved printer to a problem one and see which settings are not in agreement.
@@ -99,33 +189,6 @@ Often, I find these pages valuable in triaging a poorly behaving printer.  I com
   * Get MAC address here.
   * Set static IP assignment here if needed, else DHCP
 
-### Network Settings: Wireless 
+### Network Settings: Wireless
 <img width="484" alt="z6" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/a1a55e92-5a29-4d30-89a1-baa0f4b0837f">
   * Generally not a smooth thing to setup.  It is quite hard to fuss with these settings remotely.
-
-
-## Alternate ZDAY Styles
-why not?
-
-### Datchund, Night & Neon
-<img width="779" alt="dyldog" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/1d433b45-bbd0-4ea5-95f2-e4a89cf9fa7f">
-
-### Blue TRON
-<img width="774" alt="dyltron" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/de87a37b-1d51-4854-a7f6-a1381df8ce89">
-
-### Oakland
-<img width="774" alt="oak" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/b854f474-beb8-42bc-8f10-35ea1d1cd88d">
-
-### Petrichor
-<img width="776" alt="petrichor" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/a4e52aa8-ba1b-4634-a195-96302d44a1ec">
-
-### Daylily Garish
-<img width="778" alt="dylyel" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/651e1e47-aa1f-4f45-ac22-49764a7fda2e">
-
-### Daylily FLWRZ
-<img width="778" alt="dylflr" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/a628e721-26a8-44fa-91f9-71765938a8bc">
-
-### Triangles
-<img width="778" alt="dyltri" src="https://github.com/Daylily-Informatics/zebra_day/assets/4713659/af52353d-b188-439c-afaa-ae47cca61399">
-
-


### PR DESCRIPTION
## Summary

Updates all `.md` documentation to reflect the current state of the 2.0.0 codebase.

## Changes

### README.md
- Replace `black --check` with `ruff format --check` in linting commands
- Update all `scan-results` lab references to `default` (5 occurrences)

### MODERNIZE.md
- Replace `black --check` with `ruff format --check`

### zebra_day/docs/programatic_guide.md
- Update lab examples from `scan-results` to `default`
- Remove obsolete `Download-Label-png` virtual printer from schema example
- Add documentation for new `/api/v1/render` endpoint with curl examples

### zebra_day/docs/zebra_day_ui_guide.md
- Add comprehensive API curl examples section covering:
  - Health checks
  - Printer operations
  - Print labels
  - Render labels (PNG preview)
  - Template operations
  - Configuration
- Remove legacy "Alternate ZDAY Styles" section (themes no longer exist in 2.0.0)

### scripts/capture_screenshots.py (NEW)
- Playwright-based script for automated screenshot capture
- Captures Dashboard, Printers, Print, Templates, Config, and API Docs pages
- Usage: `python scripts/capture_screenshots.py --url https://localhost:8118`

## Testing

- [x] All 106 tests passing
- [x] Ruff lint checks pass
- [x] Ruff format checks pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author