### PR TITLE
[codex] Tighten Zebra Day Cognito domain policy

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -206,7 +206,8 @@ def test_build_user_identity_normalizes_cognito_groups_to_roles():
         cognito_group_role_map={
             "zebra-day-admin": "ADMIN",
             "zebra-day-operator": "OPERATOR",
-        }
+        },
+        allowed_email_domains=["example.com"],
     )
 
     identity = auth.build_user_identity(
@@ -221,6 +222,29 @@ def test_build_user_identity_normalizes_cognito_groups_to_roles():
 
     assert identity["cognito_groups"] == ["zebra-day-admin"]
     assert identity["roles"] == ["ADMIN", "OPERATOR"]
+
+
+def test_build_user_identity_rejects_email_domain_outside_allowlist():
+    settings = SimpleNamespace(
+        cognito_group_role_map={
+            "zebra-day-admin": "ADMIN",
+            "zebra-day-operator": "OPERATOR",
+        },
+        allowed_email_domains=["lsmc.com"],
+    )
+
+    with pytest.raises(auth.CognitoWebAuthError) as exc_info:
+        auth.build_user_identity(
+            {
+                "sub": "abc123",
+                "email": "user@example.com",
+                "name": "Example User",
+                "cognito:groups": ["zebra-day-admin"],
+            },
+            settings,
+        )
+
+    assert exc_info.value.reason == "blocked_domain"
 
 
 def test_redirect_and_logout_uris_prefer_daycog_contract_urls():

--- a/tests/test_modern_settings.py
+++ b/tests/test_modern_settings.py
@@ -27,10 +27,23 @@ def _set_xdg(monkeypatch, tmp_path, deployment="stage-1") -> None:
 
 def test_default_config_template_is_valid_yaml():
     content = build_default_config_template("dev").decode("utf-8")
+    payload = yaml.safe_load(content)
     assert validate_settings_yaml(content) == []
     assert "database_name: zebra-day-dev" in content
     assert "zebra-day-admin: ADMIN" in content
     assert "deployment:" in content
+    assert payload["authentication"]["session_secret_key"]
+    assert payload["authentication"]["allowed_email_domains"] == [
+        "lsmc.com",
+        "lsmc.bio",
+        "lsmc.life",
+        "daylilyinformatics.com",
+    ]
+    assert (
+        payload["authentication"]["default_tenant_id"]
+        == "00000000-0000-0000-0000-000000000000"
+    )
+    assert payload["authentication"]["auto_provision_allowed_domains"] == ["lsmc.com"]
 
 
 def test_settings_from_context_uses_env_paths(monkeypatch, tmp_path):
@@ -78,6 +91,15 @@ def test_settings_merge_file_values(monkeypatch, tmp_path):
     assert settings.host == "localhost"
     assert settings.port == 8119
     assert settings.auth_mode == "none"
+    assert settings.session_secret_key
+    assert settings.allowed_email_domains == [
+        "lsmc.com",
+        "lsmc.bio",
+        "lsmc.life",
+        "daylilyinformatics.com",
+    ]
+    assert settings.cognito_default_tenant_id == "00000000-0000-0000-0000-000000000000"
+    assert settings.cognito_auto_provision_allowed_domains == ["lsmc.com"]
     assert settings.tapdb_database_name == "zebra-day-prod-custom"
     assert settings.tapdb_env == "sandbox"
     assert settings.deployment == {

--- a/tests/test_modern_settings.py
+++ b/tests/test_modern_settings.py
@@ -39,10 +39,7 @@ def test_default_config_template_is_valid_yaml():
         "lsmc.life",
         "daylilyinformatics.com",
     ]
-    assert (
-        payload["authentication"]["default_tenant_id"]
-        == "00000000-0000-0000-0000-000000000000"
-    )
+    assert payload["authentication"]["default_tenant_id"] == "00000000-0000-0000-0000-000000000000"
     assert payload["authentication"]["auto_provision_allowed_domains"] == ["lsmc.com"]
 
 

--- a/tests/test_modern_web.py
+++ b/tests/test_modern_web.py
@@ -40,7 +40,8 @@ def _make_cognito_binding(claims: dict[str, object], profile_claims: dict[str, o
                 cognito_group_role_map={
                     "zebra-day-admin": "ADMIN",
                     "zebra-day-operator": "OPERATOR",
-                }
+                },
+                allowed_email_domains=["example.com", "lsmc.com"],
             ),
         )
         return SessionPrincipal(
@@ -274,6 +275,37 @@ def test_auth_error_reason_auth_error_returns_sign_in_page(tmp_path, monkeypatch
     assert response.status_code == 403
     assert "/auth/login" in response.text
     assert 'data-testid="auth-error-login"' in response.text
+
+
+def test_auth_error_reason_blocked_domain_returns_domain_message(tmp_path, monkeypatch):
+    app = _make_cognito_app(
+        tmp_path,
+        monkeypatch,
+        claims={"sub": "user", "username": "user", "cognito:groups": ["zebra-day-operator"]},
+        profile_claims={"email": "user@example.com", "name": "Example User"},
+    )
+    with _cognito_client(app) as test_client:
+        response = test_client.get("/auth/error?reason=blocked_domain")
+    assert response.status_code == 403
+    assert "Email domain not allowed" in response.text
+
+
+def test_auth_callback_redirects_to_blocked_domain_for_disallowed_email(tmp_path, monkeypatch):
+    app = _make_cognito_app(
+        tmp_path,
+        monkeypatch,
+        claims={"sub": "user", "username": "atlas-user", "cognito:groups": ["zebra-day-admin"]},
+        profile_claims={"email": "admin@gmail.com", "name": "Admin User"},
+    )
+    with _cognito_client(app) as test_client:
+        login_response = test_client.get("/auth/login", follow_redirects=False)
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+        response = test_client.get(
+            f"/auth/callback?code=code-123&state={state}",
+            follow_redirects=False,
+        )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/auth/error?reason=blocked_domain"
 
 
 def test_prod_deployment_hides_top_banner(tmp_path, monkeypatch):

--- a/tests/test_observability_contract.py
+++ b/tests/test_observability_contract.py
@@ -204,7 +204,7 @@ def test_my_health_and_auth_health_require_and_report_authenticated_sessions(mon
         tmp_path,
         monkeypatch,
         claims={"sub": "user", "username": "atlas-user", "cognito:groups": ["zebra-day-admin"]},
-        profile_claims={"email": "admin@example.com", "name": "Admin User"},
+        profile_claims={"email": "admin@lsmc.bio", "name": "Admin User"},
     )
 
     with TestClient(app, base_url="https://localhost:8118") as client:
@@ -222,7 +222,7 @@ def test_my_health_and_auth_health_require_and_report_authenticated_sessions(mon
 
     _assert_frame(my_health_payload)
     assert "principal" in my_health_payload
-    assert my_health_payload["principal"]["email"] == "admin@example.com"
+    assert my_health_payload["principal"]["email"] == "admin@lsmc.bio"
     assert my_health_payload["principal"]["roles"] == ["ADMIN", "OPERATOR"]
 
     _assert_frame(auth_payload)

--- a/zebra_day/settings.py
+++ b/zebra_day/settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import colorsys
 import hashlib
 import os
+import secrets
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,24 @@ DEFAULT_COGNITO_GROUP_ROLE_MAP = {
     "zebra-day-admin": "ADMIN",
     "zebra-day-operator": "OPERATOR",
 }
+DEFAULT_ALLOWED_EMAIL_DOMAINS = [
+    "lsmc.com",
+    "lsmc.bio",
+    "lsmc.life",
+    "daylilyinformatics.com",
+]
+ZERO_TENANT_ID = "00000000-0000-0000-0000-000000000000"
+_DEFAULT_SESSION_SECRET_KEY = os.environ.get("ZEBRA_DAY_SESSION_SECRET") or secrets.token_urlsafe(64)
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return [str(value).strip()]
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -78,9 +97,13 @@ def build_default_config_template(deployment: str | None = None) -> bytes:
             "mode": DEFAULT_AUTH_MODE,
             "internal_api_key_env": "INTERNAL_API_KEY",
             "session_cookie_name": "zebra_day_session",
+            "session_secret_key": _DEFAULT_SESSION_SECRET_KEY,
             "callback_path": "/auth/callback",
             "logout_path": "/auth/logout",
             "group_role_map": DEFAULT_COGNITO_GROUP_ROLE_MAP,
+            "allowed_email_domains": list(DEFAULT_ALLOWED_EMAIL_DOMAINS),
+            "default_tenant_id": ZERO_TENANT_ID,
+            "auto_provision_allowed_domains": ["lsmc.com"],
         },
         "tapdb": {
             "client_id": DEFAULT_TAPDB_CLIENT_ID,
@@ -131,6 +154,16 @@ def validate_settings_yaml(content: str) -> list[str]:
             if str(key).strip()
         }:
             errors.append("authentication.group_role_map values must be OPERATOR or ADMIN")
+        if not str(auth.get("session_secret_key") or "").strip():
+            errors.append("authentication.session_secret_key is required")
+        if not _normalize_string_list(auth.get("allowed_email_domains")):
+            errors.append("authentication.allowed_email_domains must contain at least one domain")
+        if not str(auth.get("default_tenant_id") or "").strip():
+            errors.append("authentication.default_tenant_id is required")
+        if not _normalize_string_list(auth.get("auto_provision_allowed_domains")):
+            errors.append(
+                "authentication.auto_provision_allowed_domains must contain at least one domain"
+            )
 
     tapdb = config.get("tapdb") or {}
     if isinstance(tapdb, dict):
@@ -161,7 +194,11 @@ class ZebraDaySettings:
     css_theme: str
     auth_mode: str
     internal_api_key: str
+    session_secret_key: str
     session_cookie_name: str
+    allowed_email_domains: list[str]
+    cognito_default_tenant_id: str
+    cognito_auto_provision_allowed_domains: list[str]
     tapdb_client_id: str
     tapdb_database_name: str
     tapdb_env: str
@@ -237,7 +274,19 @@ class ZebraDaySettings:
             internal_api_key=str(
                 os.environ.get(str(auth.get("internal_api_key_env") or "INTERNAL_API_KEY")) or ""
             ).strip(),
+            session_secret_key=str(
+                auth.get("session_secret_key") or _DEFAULT_SESSION_SECRET_KEY
+            ).strip(),
             session_cookie_name=str(auth.get("session_cookie_name") or "zebra_day_session"),
+            allowed_email_domains=_normalize_string_list(
+                auth.get("allowed_email_domains") or DEFAULT_ALLOWED_EMAIL_DOMAINS
+            )
+            or list(DEFAULT_ALLOWED_EMAIL_DOMAINS),
+            cognito_default_tenant_id=str(auth.get("default_tenant_id") or ZERO_TENANT_ID).strip(),
+            cognito_auto_provision_allowed_domains=_normalize_string_list(
+                auth.get("auto_provision_allowed_domains") or ["lsmc.com"]
+            )
+            or ["lsmc.com"],
             tapdb_client_id=client_id,
             tapdb_database_name=database_name,
             tapdb_env=env_name,

--- a/zebra_day/settings.py
+++ b/zebra_day/settings.py
@@ -35,7 +35,9 @@ DEFAULT_ALLOWED_EMAIL_DOMAINS = [
     "daylilyinformatics.com",
 ]
 ZERO_TENANT_ID = "00000000-0000-0000-0000-000000000000"
-_DEFAULT_SESSION_SECRET_KEY = os.environ.get("ZEBRA_DAY_SESSION_SECRET") or secrets.token_urlsafe(64)
+_DEFAULT_SESSION_SECRET_KEY = os.environ.get("ZEBRA_DAY_SESSION_SECRET") or secrets.token_urlsafe(
+    64
+)
 
 
 def _normalize_string_list(value: Any) -> list[str]:

--- a/zebra_day/web/app.py
+++ b/zebra_day/web/app.py
@@ -77,6 +77,11 @@ _AUTH_ERROR_REASONS: dict[str, tuple[str, str, int]] = {
         "Your account is authenticated, but it does not have the ADMIN role needed for this page.",
         403,
     ),
+    "blocked_domain": (
+        "Email domain not allowed",
+        "This account's email domain is not allowed for Zebra Day access.",
+        403,
+    ),
 }
 
 

--- a/zebra_day/web/auth.py
+++ b/zebra_day/web/auth.py
@@ -91,15 +91,29 @@ def _normalize_cognito_domain(value: Any) -> str:
     return raw.removeprefix("https://").removeprefix("http://").rstrip("/")
 
 
+def _email_domain(email: str) -> str:
+    _, _, domain = str(email or "").strip().lower().partition("@")
+    return domain
+
+
 def build_user_identity(claims: dict[str, Any], settings: ZebraDaySettings) -> dict[str, Any]:
     merged_claims = dict(claims)
+    email = _clean(merged_claims.get("email")).lower()
+    domain = _email_domain(email)
+    if not email or domain not in {item.lower() for item in settings.allowed_email_domains}:
+        raise CognitoWebAuthError(
+            "blocked_domain",
+            "Email domain is not allowed",
+            status_code=status.HTTP_403_FORBIDDEN,
+            redirect_to_error=True,
+        )
     groups = parse_groups(merged_claims.get("cognito:groups"))
     roles = roles_from_groups(groups, settings.cognito_group_role_map)
     merged_claims["cognito_groups"] = groups
     merged_claims["roles"] = roles
     return {
         "sub": _clean(merged_claims.get("sub") or merged_claims.get("username")),
-        "email": _clean(merged_claims.get("email")),
+        "email": email,
         "name": _clean(
             merged_claims.get("name")
             or merged_claims.get("cognito:username")
@@ -216,10 +230,7 @@ def get_server_instance_id() -> str:
 
 
 def _session_secret(settings: ZebraDaySettings) -> str:
-    return (
-        os.environ.get("ZEBRA_DAY_SESSION_SECRET")
-        or f"zebra-day-{settings.deployment_code}-dev-secret"
-    )
+    return os.environ.get("ZEBRA_DAY_SESSION_SECRET") or settings.session_secret_key
 
 
 def _runtime_public_base_url(settings: ZebraDaySettings) -> str:

--- a/zebra_day/web/auth.py
+++ b/zebra_day/web/auth.py
@@ -34,7 +34,7 @@ from starlette.responses import RedirectResponse, Response
 
 from zebra_day.logging_config import get_logger
 from zebra_day.rbac import parse_groups, roles_from_groups
-from zebra_day.settings import ZebraDaySettings
+from zebra_day.settings import DEFAULT_ALLOWED_EMAIL_DOMAINS, ZebraDaySettings
 
 _log = get_logger(__name__)
 
@@ -100,7 +100,8 @@ def build_user_identity(claims: dict[str, Any], settings: ZebraDaySettings) -> d
     merged_claims = dict(claims)
     email = _clean(merged_claims.get("email")).lower()
     domain = _email_domain(email)
-    if not email or domain not in {item.lower() for item in settings.allowed_email_domains}:
+    allowed_domains = getattr(settings, "allowed_email_domains", DEFAULT_ALLOWED_EMAIL_DOMAINS)
+    if not email or domain not in {item.lower() for item in allowed_domains}:
         raise CognitoWebAuthError(
             "blocked_domain",
             "Email domain is not allowed",


### PR DESCRIPTION
## What changed
- added Zebra Day email-domain allowlist enforcement for Cognito identities
- added config-init session secret generation plus zero-tenant and auto-provision parity fields
- updated the modern auth/settings/web tests to cover the new policy

## Why
Dayhoff local builds now emit a fixed auth-domain policy. Zebra Day needed matching repo-native config and login enforcement so local deployments do not keep accepting broader domains.

## Validation
- `source ./activate local && python -m pytest tests/test_modern_settings.py tests/test_auth.py tests/test_modern_web.py -q`
