### PR TITLE
Migrate Zebra auth integration to daylily-auth-cognito

### DIFF
--- a/AWS_DYNAMO_CONFIG_PLAN.md
+++ b/AWS_DYNAMO_CONFIG_PLAN.md
@@ -5,6 +5,8 @@
 > **Date**: 2026-02-06
 > **Scope**: `zebra_day` — shared printer config + ZPL templates via DynamoDB, with S3 backups
 
+Zebra's Cognito integration now uses `daylily-auth-cognito` 2.0 for browser/session auth, runtime verification, and `daycog`-driven lifecycle management. Keep service runtime code out of `daylily_auth_cognito.cli`.
+
 ---
 
 ## 1. Problem Statement
@@ -598,7 +600,7 @@ aws = [
     "boto3>=1.26.0",
 ]
 auth = [
-    "daylily-cognito>=0.1.10",
+    "daylily-auth-cognito>=0.1.10",
     "python-jose[cryptography]>=3.3.0",
     "boto3>=1.26.0",
 ]

--- a/docs/major_refactor.md
+++ b/docs/major_refactor.md
@@ -7,6 +7,8 @@ Implementation handoff for the approved `zebra_day` major release.
 This release turns `zebra_day` into a deployment-scoped, TapDB-backed, first-level
 service and library.
 
+For Cognito, Zebra now relies on the `daylily-auth-cognito` 2.0 split: browser sessions use `browser.session`, Hosted UI helpers use `browser.oauth` and `browser.google`, bearer verification uses `runtime.verifier`, and shared Cognito lifecycle stays in `daycog` via `admin.*`. Service runtime code should not import `daylily_auth_cognito.cli`.
+
 - Runtime activation moves to Atlas-style `source ./activate`.
 - Local flat files stop being the runtime source of truth for printer fleet state.
 - TapDB becomes the primary authority for printers, label profiles, templates, and
@@ -156,7 +158,7 @@ Deliverables:
 Ownership:
 - coordinated PRs in `dayhoff`
 - coordinated PRs in `bloom`
-- any required touchpoints in `daylily-cognito` or `daylily-tapdb`
+- any required touchpoints in `daylily-auth-cognito` or `daylily-tapdb`
 
 Deliverables:
 - Dayhoff:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "python-multipart>=0.0.6",
     "cli-core-yo>=1.3.1",
-    "daylily-cognito==1.2.0",
+    "daylily-auth-cognito==2.0.1",
     "daylily-tapdb==4.1.1",
     "typer>=0.21.0,<0.22.0",
     "rich>=14.0.0,<15.0.0",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,7 @@ Tests for the zebra_day authentication module.
 
 import sys
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -55,20 +55,14 @@ class TestSetupCognitoAuth:
     """Tests for setup_cognito_auth function."""
 
     def test_setup_cognito_raises_import_error_when_unavailable(self):
-        """Test setup_cognito_auth raises ImportError when daylily-cognito not installed."""
+        """Test setup_cognito_auth raises ImportError when daylily-auth-cognito not installed."""
         if not auth.is_cognito_available():
             with pytest.raises(ImportError) as exc_info:
                 auth.setup_cognito_auth(None, None)
-            assert "daylily-cognito" in str(exc_info.value)
+            assert "daylily-auth-cognito" in str(exc_info.value)
 
 
 def test_exchange_code_verifies_access_token_and_profiles_from_id_token():
-    oauth = SimpleNamespace(
-        exchange_authorization_code=lambda **kwargs: {
-            "access_token": "access-token",
-            "id_token": "id-token",
-        }
-    )
     auth_client = SimpleNamespace(
         verify_token=lambda token: (
             {"sub": "access-sub", "username": "atlas-user"}
@@ -86,10 +80,19 @@ def test_exchange_code_verifies_access_token_and_profiles_from_id_token():
             user_pool_id="pool-id",
         ),
         auth=auth_client,
-        oauth=oauth,
         jwks=jwks,
     )
     binding.redirect_uri = lambda request: "https://localhost:8118/auth/callback"
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "daylily_auth_cognito.browser.session.exchange_authorization_code_async",
+        AsyncMock(
+            return_value={
+                "access_token": "access-token",
+                "id_token": "id-token",
+            }
+        ),
+    )
 
     def _verify_id_token(token, *, access_token=None):
         assert access_token == "access-token"
@@ -104,19 +107,16 @@ def test_exchange_code_verifies_access_token_and_profiles_from_id_token():
 
     binding._verify_id_token = _verify_id_token
 
-    result = binding.exchange_code(object(), "auth-code")
+    try:
+        result = binding.exchange_code(object(), "auth-code")
+    finally:
+        monkeypatch.undo()
 
     assert result["claims"]["sub"] == "access-sub"
     assert result["profile_claims"]["email"] == "user@example.com"
 
 
 def test_exchange_code_falls_back_to_unverified_id_token_profile_decode():
-    oauth = SimpleNamespace(
-        exchange_authorization_code=lambda **kwargs: {
-            "access_token": "access-token",
-            "id_token": "id-token",
-        }
-    )
     auth_client = SimpleNamespace(
         verify_token=lambda token: (
             {"sub": "access-sub", "username": "atlas-user"}
@@ -133,10 +133,19 @@ def test_exchange_code_falls_back_to_unverified_id_token_profile_decode():
             user_pool_id="pool-id",
         ),
         auth=auth_client,
-        oauth=oauth,
         jwks=SimpleNamespace(),
     )
     binding.redirect_uri = lambda request: "https://localhost:8118/auth/callback"
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "daylily_auth_cognito.browser.session.exchange_authorization_code_async",
+        AsyncMock(
+            return_value={
+                "access_token": "access-token",
+                "id_token": "id-token",
+            }
+        ),
+    )
 
     def _verify_id_token(token, *, access_token=None):
         assert access_token == "access-token"
@@ -152,19 +161,16 @@ def test_exchange_code_falls_back_to_unverified_id_token_profile_decode():
         else pytest.fail("expected id token fallback decode")
     )
 
-    result = binding.exchange_code(object(), "auth-code")
+    try:
+        result = binding.exchange_code(object(), "auth-code")
+    finally:
+        monkeypatch.undo()
 
     assert result["claims"]["sub"] == "access-sub"
     assert result["profile_claims"]["email"] == "fallback@example.com"
 
 
 def test_exchange_code_continues_when_id_token_cannot_be_decoded():
-    oauth = SimpleNamespace(
-        exchange_authorization_code=lambda **kwargs: {
-            "access_token": "access-token",
-            "id_token": "id-token",
-        }
-    )
     auth_client = SimpleNamespace(
         verify_token=lambda token: (
             {"sub": "access-sub", "username": "atlas-user"}
@@ -181,10 +187,19 @@ def test_exchange_code_continues_when_id_token_cannot_be_decoded():
             user_pool_id="pool-id",
         ),
         auth=auth_client,
-        oauth=oauth,
         jwks=SimpleNamespace(),
     )
     binding.redirect_uri = lambda request: "https://localhost:8118/auth/callback"
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "daylily_auth_cognito.browser.session.exchange_authorization_code_async",
+        AsyncMock(
+            return_value={
+                "access_token": "access-token",
+                "id_token": "id-token",
+            }
+        ),
+    )
 
     def _verify_id_token(token, *, access_token=None):
         assert access_token == "access-token"
@@ -195,7 +210,10 @@ def test_exchange_code_continues_when_id_token_cannot_be_decoded():
         ValueError("payload failed")
     )
 
-    result = binding.exchange_code(object(), "auth-code")
+    try:
+        result = binding.exchange_code(object(), "auth-code")
+    finally:
+        monkeypatch.undo()
 
     assert result["claims"]["sub"] == "access-sub"
     assert result["profile_claims"] == {}
@@ -255,7 +273,6 @@ def test_redirect_and_logout_uris_prefer_daycog_contract_urls():
             logout_url="https://0.0.0.0:8118/login",
         ),
         auth=SimpleNamespace(),
-        oauth=SimpleNamespace(),
         jwks=SimpleNamespace(),
     )
 
@@ -280,7 +297,6 @@ def test_build_logout_url_uses_callback_uri_for_managed_login(monkeypatch):
             logout_url="https://0.0.0.0:8118/login",
         ),
         auth=SimpleNamespace(),
-        oauth=SimpleNamespace(),
         jwks=SimpleNamespace(),
     )
 
@@ -289,8 +305,7 @@ def test_build_logout_url_uses_callback_uri_for_managed_login(monkeypatch):
     assert url == "https://example.com/logout"
     assert captured["domain"] == "example.com"
     assert captured["client_id"] == "client-id"
-    assert captured["redirect_uri"] == "https://localhost:8118/auth/callback"
-    assert "logout_uri" not in captured
+    assert captured["logout_uri"] == "https://localhost:8118/login"
 
 
 def test_load_daycog_contract_prefers_process_env_and_normalizes_domain(monkeypatch):
@@ -372,8 +387,7 @@ def test_verify_id_token_passes_paired_access_token_to_jose_decode(monkeypatch):
             region="us-west-2",
             user_pool_id="pool-id",
         ),
-        auth=SimpleNamespace(_jwks_cache=jwks_cache),
-        oauth=SimpleNamespace(),
+        auth=SimpleNamespace(cache=jwks_cache),
         jwks=SimpleNamespace(
             JWKSCache=lambda region, pool_id: pytest.fail("unexpected JWKS cache init")
         ),
@@ -391,7 +405,6 @@ def test_decode_id_token_unverified_disables_at_hash_verification(monkeypatch):
         settings=SimpleNamespace(),
         config=SimpleNamespace(),
         auth=SimpleNamespace(),
-        oauth=SimpleNamespace(),
         jwks=SimpleNamespace(),
     )
 

--- a/tests/test_deploy_contract.py
+++ b/tests/test_deploy_contract.py
@@ -23,7 +23,7 @@ def test_activate_uses_root_environment_yaml_and_repo_only_editable_install() ->
     assert 'pip install -e "${ZEBRA_DAY_PROJECT_ROOT}"' in activate
     assert "[dev,lint,auth]" not in activate
     assert "../daylily-tapdb" not in activate
-    assert "../daylily-cognito" not in activate
+    assert "../daylily-auth-cognito" not in activate
     assert "../cli-core-yo" not in activate
 
 

--- a/tests/test_modern_web.py
+++ b/tests/test_modern_web.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
 
 from fastapi.testclient import TestClient
@@ -87,11 +88,13 @@ def _make_cognito_app(
         lambda app, settings: _make_cognito_binding(claims, profile_claims),
     )
     monkeypatch.setattr(
-        "daylily_cognito.web_session.exchange_authorization_code",
-        lambda **kwargs: {
-            "access_token": "access-token",
-            "id_token": "id-token",
-        },
+        "daylily_auth_cognito.browser.session.exchange_authorization_code_async",
+        AsyncMock(
+            return_value={
+                "access_token": "access-token",
+                "id_token": "id-token",
+            }
+        ),
     )
     monkeypatch.setattr("zebra_day.web.app.get_local_ip", lambda: "192.168.1.10")
     return create_app(auth="cognito", client=_seed_client(tmp_path, monkeypatch))
@@ -370,7 +373,7 @@ def test_cognito_session_expired_after_restart_redirects_to_error(tmp_path, monk
             server_instance_id="new-server-instance",
         )
         app.state.web_session_config = new_config
-        app.state.__dict__["_daylily_cognito_web_session_config"] = new_config
+        app.state.__dict__["_daylily_auth_cognito_web_session_config"] = new_config
         response = test_client.get("/printers", follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["location"] == "/auth/error?reason=session_expired"

--- a/tests/test_observability_contract.py
+++ b/tests/test_observability_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
 
 from fastapi.testclient import TestClient
@@ -85,11 +86,13 @@ def _make_cognito_app(
         lambda app, settings: _make_cognito_binding(claims, profile_claims),
     )
     monkeypatch.setattr(
-        "daylily_cognito.web_session.exchange_authorization_code",
-        lambda **kwargs: {
-            "access_token": "access-token",
-            "id_token": "id-token",
-        },
+        "daylily_auth_cognito.browser.session.exchange_authorization_code_async",
+        AsyncMock(
+            return_value={
+                "access_token": "access-token",
+                "id_token": "id-token",
+            }
+        ),
     )
     monkeypatch.setattr("zebra_day.web.app.get_local_ip", lambda: "192.168.1.10")
     return create_app(auth="cognito", client=_seed_client(tmp_path, monkeypatch))

--- a/zebra_day/observability.py
+++ b/zebra_day/observability.py
@@ -299,7 +299,7 @@ class ZebraDayObservability:
         rich_auth = "none" if auth_mode == "none" else "bearer_token"
         configured_dependencies = ["daylily-tapdb"]
         if auth_mode == "cognito":
-            configured_dependencies.insert(0, "daylily-cognito")
+            configured_dependencies.insert(0, "daylily-auth-cognito")
         endpoints = [
             {"path": "/healthz", "auth": "none", "kind": "liveness"},
             {"path": "/readyz", "auth": "none", "kind": "readiness"},

--- a/zebra_day/web/auth.py
+++ b/zebra_day/web/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import os
 import secrets
@@ -10,15 +11,13 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from urllib.parse import quote, urlsplit, urlunsplit
 
-import daylily_cognito as daycog
-from daylily_cognito import jwks
-from daylily_cognito import oauth as cognito_oauth
-from daylily_cognito.config import load_config_file_if_present
-from daylily_cognito.oauth import build_logout_url
-from daylily_cognito.web_session import (
+import yaml
+from daylily_auth_cognito.browser import session as cognito_session
+from daylily_auth_cognito.browser.oauth import build_logout_url
+from daylily_auth_cognito.browser.session import (
     CognitoWebAuthError,
     CognitoWebSessionConfig,
     SessionPrincipal,
@@ -28,6 +27,8 @@ from daylily_cognito.web_session import (
     load_session_principal,
     start_cognito_login,
 )
+from daylily_auth_cognito.runtime import jwks
+from daylily_auth_cognito.runtime.verifier import CognitoTokenVerifier
 from fastapi import Request, status
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse, Response
@@ -129,7 +130,7 @@ def build_user_identity(claims: dict[str, Any], settings: ZebraDaySettings) -> d
 
 def is_cognito_available() -> bool:
     try:
-        import daylily_cognito  # noqa: F401
+        import daylily_auth_cognito  # noqa: F401
 
         return True
     except ImportError:
@@ -138,7 +139,7 @@ def is_cognito_available() -> bool:
 
 def get_cognito_import_error() -> str | None:
     try:
-        import daylily_cognito  # noqa: F401
+        import daylily_auth_cognito  # noqa: F401
 
         return None
     except ImportError as exc:
@@ -152,10 +153,16 @@ def _daycog_config_path() -> Path:
 
 
 def _load_daycog_file_values() -> dict[str, str]:
-    return cast(
-        dict[str, str],
-        load_config_file_if_present(_daycog_config_path(), require_required_keys=False),
-    )
+    path = _daycog_config_path()
+    if not path.exists():
+        return {}
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {str(key): str(value) for key, value in payload.items() if value is not None}
 
 
 def load_daycog_contract() -> dict[str, str]:
@@ -316,7 +323,6 @@ class CognitoBinding:
     settings: ZebraDaySettings
     config: Any
     auth: Any
-    oauth: Any
     jwks: Any
     web_session_config: CognitoWebSessionConfig | None = None
 
@@ -349,7 +355,7 @@ class CognitoBinding:
         state = secrets.token_urlsafe(24)
         request.session["oauth_state"] = state
         return str(
-            self.oauth.build_authorization_url(
+            cognito_session.build_authorization_url(
                 domain=self.config.cognito_domain,
                 client_id=self.config.app_client_id,
                 redirect_uri=self.redirect_uri(request),
@@ -362,7 +368,7 @@ class CognitoBinding:
             build_logout_url(
                 domain=self.config.cognito_domain,
                 client_id=self.config.app_client_id,
-                redirect_uri=self.redirect_uri(request),
+                logout_uri=self.logout_uri(request),
             )
         )
 
@@ -373,7 +379,7 @@ class CognitoBinding:
         if not kid:
             raise ValueError("Cognito id token is missing a kid header")
 
-        cache = getattr(self.auth, "_jwks_cache", None)
+        cache = getattr(self.auth, "cache", None)
         if cache is None:
             cache = self.jwks.JWKSCache(self.config.region, self.config.user_pool_id)
         key = cache.get_key(kid)
@@ -421,11 +427,13 @@ class CognitoBinding:
         return dict(claims)
 
     def exchange_code(self, request: Request, code: str) -> dict[str, Any]:
-        tokens = self.oauth.exchange_authorization_code(
-            domain=self.config.cognito_domain,
-            client_id=self.config.app_client_id,
-            code=code,
-            redirect_uri=self.redirect_uri(request),
+        tokens = asyncio.run(
+            cognito_session.exchange_authorization_code_async(
+                domain=self.config.cognito_domain,
+                client_id=self.config.app_client_id,
+                code=code,
+                redirect_uri=self.redirect_uri(request),
+            )
         )
         access_token = _clean(tokens.get("access_token"))
         if not access_token:
@@ -507,22 +515,20 @@ def setup_cognito_auth(_app, settings: ZebraDaySettings) -> CognitoBinding:
     """Create a Cognito binding from the configured daycog runtime contract."""
     if not is_cognito_available():
         raise ImportError(
-            "daylily-cognito is required for Cognito authentication. "
+            "daylily-auth-cognito is required for Cognito authentication. "
             f"Import error: {get_cognito_import_error()}"
         )
     contract = load_daycog_contract()
     config = SimpleNamespace(**contract)
-    auth = daycog.CognitoAuth(
+    auth = CognitoTokenVerifier(
         region=config.region,
         user_pool_id=config.user_pool_id,
         app_client_id=config.app_client_id,
-        profile=_clean(config.aws_profile) or None,
     )
     return CognitoBinding(
         settings=settings,
         config=config,
         auth=auth,
-        oauth=cognito_oauth,
         jwks=jwks,
         web_session_config=build_web_session_config(settings),
     )


### PR DESCRIPTION
## Summary
- switch Zebra's Cognito integration to `daylily-auth-cognito` 2.0 surfaces
- update auth/web/observability tests and docs for the new package boundary
- keep the current local auth-domain refactor mergeable before the CLI v2 rollout starts

## Validation
- `/Users/jmajor/projects/daylily/zebra_day/.venv-prep-zebra312/bin/python -m pytest tests/test_auth.py tests/test_modern_web.py tests/test_observability_contract.py tests/test_deploy_contract.py -q`
