### PR TITLE
Pin Zebra to cli-core-yo v1 before v2 migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "itsdangerous>=2.2.0",
     "pydantic>=2.0.0",
     "python-multipart>=0.0.6",
-    "cli-core-yo>=1.3.1",
+    "cli-core-yo>=1.3.1,<2.0.0",
     "daylily-auth-cognito==2.0.1",
     "daylily-tapdb==4.1.1",
     "typer>=0.21.0,<0.22.0",


### PR DESCRIPTION
## Summary
- cap Zebra's pre-migration cli-core-yo range below 2.0.0
- keep fresh installs on the last compatible framework while Zebra still uses the v1 CLI contract
- unblock clean local validation before the actual Zebra CLI v2 branch starts

## Validation
- `/Users/jmajor/projects/daylily/zebra_day/.venv/bin/python -m pip install -e .`
- `/Users/jmajor/projects/daylily/zebra_day/.venv/bin/zday --help`
- `/Users/jmajor/projects/daylily/zebra_day/.venv/bin/python -m pytest tests/test_auth.py tests/test_modern_web.py tests/test_observability_contract.py tests/test_deploy_contract.py -q`
