### PR TITLE
Release zebra_day 6.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "python-multipart>=0.0.6",
     "cli-core-yo==2.1.1",
     "daylily-auth-cognito==2.1.5",
-    "daylily-tapdb==6.0.9",
+    "daylily-tapdb @ git+https://github.com/Daylily-Informatics/daylily-tapdb.git@6.0.10",
     "typer>=0.21.0,<0.22.0",
     "rich>=14.0.0,<15.0.0",
     "pillow>=10.0.0",

--- a/tests/test_deploy_contract.py
+++ b/tests/test_deploy_contract.py
@@ -82,7 +82,10 @@ def test_pyproject_owns_python_dependencies_and_console_scripts() -> None:
     assert "optional-dependencies" not in pyproject["project"]
     assert "cli-core-yo==2.1.1" in dependencies
     assert "daylily-auth-cognito==2.1.5" in dependencies
-    assert "daylily-tapdb==6.0.9" in dependencies
+    assert (
+        "daylily-tapdb @ git+https://github.com/Daylily-Informatics/daylily-tapdb.git@6.0.10"
+        in dependencies
+    )
     assert "boto3>=1.26.0" in dependencies
     assert "awscli" in dependencies
     assert "bandit[toml]>=1.8.0" in dependencies

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -8,6 +8,8 @@ def _tapdb_version(dependencies: list[str]) -> str:
     for dependency in dependencies:
         if dependency.startswith("daylily-tapdb=="):
             return dependency.split("==", 1)[1]
+        if dependency.startswith("daylily-tapdb @ ") and "@" in dependency:
+            return dependency.rsplit("@", 1)[1].strip()
     raise AssertionError("daylily-tapdb dependency is missing")
 
 
@@ -20,5 +22,8 @@ def test_pyproject_pins_release_train_dependencies() -> None:
 
     assert "cli-core-yo==2.1.1" in dependencies
     assert "daylily-auth-cognito==2.1.5" in dependencies
-    assert f"daylily-tapdb=={tapdb_version}" in dependencies
+    assert (
+        f"daylily-tapdb @ git+https://github.com/Daylily-Informatics/daylily-tapdb.git@{tapdb_version}"
+        in dependencies
+    )
     assert all("daylily-cognito" not in dependency for dependency in dependencies)

--- a/zebra_day/client.py
+++ b/zebra_day/client.py
@@ -63,6 +63,8 @@ def _pyproject_dependency_version(dependency_name: str) -> str:
     for dependency in data["project"]["dependencies"]:
         if dependency.startswith(f"{dependency_name}=="):
             return str(dependency.split("==", 1)[1])
+        if dependency.startswith(f"{dependency_name} @ ") and "@" in dependency:
+            return str(dependency.rsplit("@", 1)[1].strip())
     raise RuntimeError(f"Missing pinned dependency: {dependency_name}")
 
 


### PR DESCRIPTION
## Summary
- merges the deployed zebra_day 6.0.5 release commits back into GitHub main
- prepares main for the next release tag 6.0.6

## Validation
- GitHub CI will run on this PR
