### PR TITLE
[codex] Release Zebra Day no-fallback auth cutover

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,6 +40,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.12", "3.13"]
     runs-on: ${{ matrix.os }}
+    env:
+      ZEBRA_DAY_DEPLOYMENT_CODE: ci
+      DEPLOYMENT_CODE: ci
+      LSMC_DEPLOYMENT_CODE: ci
+      ZEBRA_DAY_SESSION_SECRET: zebra-day-ci-session-secret
+      XDG_CONFIG_HOME: ${{ runner.temp }}/zebra-day/config
+      XDG_DATA_HOME: ${{ runner.temp }}/zebra-day/data
+      XDG_STATE_HOME: ${{ runner.temp }}/zebra-day/state
+      XDG_CACHE_HOME: ${{ runner.temp }}/zebra-day/cache
 
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +62,19 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+
+      - name: Prepare explicit CI runtime config
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from zebra_day.settings import build_default_config_template
+
+          config_dir = Path(__import__("os").environ["XDG_CONFIG_HOME"]) / "zebra_day"
+          config_dir.mkdir(parents=True, exist_ok=True)
+          (config_dir / "zebra-day-config-ci.yaml").write_bytes(
+              build_default_config_template("ci")
+          )
+          PY
 
       - name: Install Playwright browsers
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ templates, label profiles, observations, and print jobs in `daylily-tapdb`.
 - Do not add package installs, dependency probes, TapDB bootstrap, config copying, registry writes, loader-path hacks, or `conda install` steps to `activate`.
 - If a CLI is missing after activation, fix packaging entry points or `pyproject.toml`, not `activate`.
 - If deployment-scoped config is missing, fix `zday config init` or the explicit config/bootstrap path, not `activate`.
+- Fallback behavior is an antipattern in this workspace. Do not add, preserve, or rely on inferred config paths, deprecated CLI aliases, alternate TLS discovery, generated substitute values, compatibility shims, or silent printer/rendering success when required state is missing. Missing config, certs, TapDB namespace, printer state, renderer dependency, or malformed input must fail hard with a clear error.
 
 ## Dependency Boundary
 

--- a/config/tapdb-config-zebra-day.yaml
+++ b/config/tapdb-config-zebra-day.yaml
@@ -1,32 +1,21 @@
 meta:
-  config_version: 3
+  config_version: 4
   client_id: zebra-day
-  database_name: zebra-day
+  database_name: zebra-day-local
   owner_repo_name: zebra-day
   domain_code: Z
   domain_registry_path: /absolute/path/to/domain_code_registry.json
   prefix_registry_path: /absolute/path/to/prefix_ownership_registry.json
-environments:
-  dev:
-    engine_type: local
-    host: localhost
-    port: '5544'
-    ui_port: '8118'
-    database: zebra_day_dev
-    audit_log_euid_prefix: ZGX
-    support_email: support@lsmc.bio
-    cognito_user_pool_id: ''
-  prod:
-    engine_type: aurora
-    host: zebra-day.cluster-REPLACE.us-west-2.rds.amazonaws.com
-    port: '5432'
-    user: tapdb_admin
-    password: ''
-    database: zebra_day_prod
-    audit_log_euid_prefix: ZGX
-    support_email: support@lsmc.bio
-    cognito_user_pool_id: ''
-    region: us-west-2
-    cluster_identifier: zebra-day
-    iam_auth: 'true'
-    ssl: 'true'
+target:
+  engine_type: local
+  host: localhost
+  port: '5544'
+  ui_port: '8118'
+  user: postgres
+  password: null
+  database: tapdb_local
+  schema_name: tapdb_zebra_day_local
+  audit_log_euid_prefix: ZGX
+safety:
+  safety_tier: local
+  destructive_operations: confirm_required

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "python-multipart>=0.0.6",
     "cli-core-yo==2.1.1",
     "daylily-auth-cognito==2.1.5",
-    "daylily-tapdb==7.0.1",
+    "daylily-tapdb==7.0.3",
     "typer>=0.21.0,<0.22.0",
     "rich>=14.0.0,<15.0.0",
     "pillow>=10.0.0",
@@ -87,7 +87,6 @@ zebra_day = [
     "logs/*",
     "templates/*",
     "templates/modern/*",
-    "templates/legacy/*",
     "web/*",
 ]
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,12 +4,14 @@ Tests for the zebra_day authentication module.
 
 import sys
 import threading
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 import pytest
+import yaml
 
-from zebra_day.settings import ZebraDaySettings
+from zebra_day.settings import ZebraDaySettings, build_default_config_template
 from zebra_day.web import auth
 
 
@@ -20,6 +22,15 @@ def _set_xdg(monkeypatch, tmp_path, deployment: str = "local") -> None:
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
     monkeypatch.setenv("ZEBRA_DAY_DEPLOYMENT_CODE", deployment)
+
+
+def _write_explicit_config(tmp_path, deployment: str = "local") -> Path:
+    config_path = tmp_path / "config" / "zebra_day" / f"zebra-day-config-{deployment}.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = yaml.safe_load(build_default_config_template(deployment))
+    payload["tapdb"]["physical_database"] = f"tapdb_{deployment}"
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return config_path
 
 
 class TestCognitoAvailability:
@@ -127,7 +138,7 @@ def test_exchange_code_verifies_access_token_and_profiles_from_id_token():
     assert result["profile_claims"]["email"] == "user@example.com"
 
 
-def test_exchange_code_falls_back_to_unverified_id_token_profile_decode():
+def test_exchange_code_rejects_unverified_id_token_profile_decode():
     auth_client = SimpleNamespace(
         verify_token=lambda token: (
             {"sub": "access-sub", "username": "atlas-user"}
@@ -163,25 +174,14 @@ def test_exchange_code_falls_back_to_unverified_id_token_profile_decode():
         raise ValueError("jwt failed")
 
     binding._verify_id_token = _verify_id_token
-    binding._decode_id_token_unverified = lambda token: (
-        {
-            "email": "fallback@example.com",
-            "name": "Fallback User",
-        }
-        if token == "id-token"
-        else pytest.fail("expected id token fallback decode")
-    )
-
     try:
-        result = binding.exchange_code(object(), "auth-code")
+        with pytest.raises(ValueError, match="jwt failed"):
+            binding.exchange_code(object(), "auth-code")
     finally:
         monkeypatch.undo()
 
-    assert result["claims"]["sub"] == "access-sub"
-    assert result["profile_claims"]["email"] == "fallback@example.com"
 
-
-def test_exchange_code_continues_when_id_token_cannot_be_decoded():
+def test_exchange_code_fails_when_id_token_cannot_be_verified():
     auth_client = SimpleNamespace(
         verify_token=lambda token: (
             {"sub": "access-sub", "username": "atlas-user"}
@@ -217,17 +217,11 @@ def test_exchange_code_continues_when_id_token_cannot_be_decoded():
         raise ValueError("jwt failed")
 
     binding._verify_id_token = _verify_id_token
-    binding._decode_id_token_unverified = lambda token: (_ for _ in ()).throw(
-        ValueError("payload failed")
-    )
-
     try:
-        result = binding.exchange_code(object(), "auth-code")
+        with pytest.raises(ValueError, match="jwt failed"):
+            binding.exchange_code(object(), "auth-code")
     finally:
         monkeypatch.undo()
-
-    assert result["claims"]["sub"] == "access-sub"
-    assert result["profile_claims"] == {}
 
 
 def test_exchange_code_works_when_called_inside_running_event_loop():
@@ -434,6 +428,7 @@ def test_load_daycog_contract_falls_back_to_daycog_config_file_with_bare_host(mo
 
 def test_setup_cognito_auth_uses_runtime_settings_without_daycog(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path)
+    _write_explicit_config(tmp_path)
     monkeypatch.setenv("COGNITO_REGION", "us-west-2")
     monkeypatch.setenv("COGNITO_USER_POOL_ID", "pool-123")
     monkeypatch.setenv("COGNITO_APP_CLIENT_ID", "client-123")
@@ -511,24 +506,5 @@ def test_verify_id_token_passes_paired_access_token_to_jose_decode(monkeypatch):
     assert decode_kwargs["audience"] == "client-id"
 
 
-def test_decode_id_token_unverified_disables_at_hash_verification(monkeypatch):
-    binding = auth.CognitoBinding(
-        settings=SimpleNamespace(),
-        config=SimpleNamespace(),
-        auth=SimpleNamespace(),
-        jwks=SimpleNamespace(),
-    )
-
-    decode_mock = Mock(return_value={"email": "user@example.com"})
-    monkeypatch.setitem(
-        sys.modules,
-        "jose",
-        SimpleNamespace(
-            JWTError=ValueError,
-            jwt=SimpleNamespace(decode=decode_mock),
-        ),
-    )
-    claims = binding._decode_id_token_unverified("id-token")
-
-    assert claims["email"] == "user@example.com"
-    assert decode_mock.call_args.kwargs["options"]["verify_at_hash"] is False
+def test_unverified_id_token_decode_helper_is_removed():
+    assert not hasattr(auth.CognitoBinding, "_decode_id_token_unverified")

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -4,6 +4,7 @@ import json
 from types import SimpleNamespace
 
 import pytest
+import typer
 from click.exceptions import Abort, Exit
 
 from zebra_day.cli import cognito as cognito_module
@@ -113,11 +114,9 @@ def test_env_missing_root_and_inactive_paths(monkeypatch, tmp_path, capsys):
     assert "Could not find zebra_day project root" in activate_out
 
     monkeypatch.setenv("CONDA_DEFAULT_ENV", "ZEBRA_DAY-qa1")
-    env_module.deactivate()
-    capsys.readouterr()
-    fallback_panel = panels.pop()
-    assert "zebra_day_deactivate" in str(fallback_panel.renderable)
-    assert "deactivate" in str(fallback_panel.renderable)
+    with pytest.raises(typer.BadParameter, match="project root could not be resolved"):
+        env_module.deactivate()
+    assert panels == []
 
     with pytest.raises(Exit):
         env_module.reset()

--- a/tests/test_client_runtime.py
+++ b/tests/test_client_runtime.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+import yaml
 
 from tests.fakes import sample_repository
 from zebra_day.client import (
@@ -18,6 +19,7 @@ from zebra_day.settings import (
     DEFAULT_MERIDIAN_DOMAIN_CODE,
     DEFAULT_TAPDB_OWNER_REPO,
     ZebraDaySettings,
+    build_default_config_template,
 )
 
 
@@ -28,6 +30,18 @@ def _set_xdg(monkeypatch, tmp_path, deployment="local") -> None:
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
     monkeypatch.setenv("ZEBRA_DAY_DEPLOYMENT_CODE", deployment)
+    monkeypatch.setenv("ZEBRA_DAY_SESSION_SECRET", f"test-secret-{deployment}")
+    config_path = tmp_path / "config" / "zebra_day" / f"zebra-day-config-{deployment}.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        build_default_config_template(deployment).decode("utf-8"),
+        encoding="utf-8",
+    )
+
+
+def _write_config(path: Path, deployment: str, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
 
 
 def test_direct_client_fails_fast_without_tapdb(monkeypatch, tmp_path):
@@ -43,16 +57,15 @@ def test_tapdb_fleet_repository_builds_connection_with_zebra_scope(monkeypatch, 
     tapdb_config_path = tmp_path / "tapdb" / "zebra-day" / "zebra-day-local" / "tapdb-config.yaml"
     domain_registry_path = tmp_path / "tapdb-registry" / "domain_code_registry.json"
     prefix_registry_path = tmp_path / "tapdb-registry" / "prefix_ownership_registry.json"
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(
-        (
-            "tapdb:\n"
-            f"  config_path: {tapdb_config_path}\n"
-            f"  domain_registry_path: {domain_registry_path}\n"
-            f"  prefix_ownership_registry_path: {prefix_registry_path}\n"
-        ),
-        encoding="utf-8",
+    payload = yaml.safe_load(build_default_config_template("local").decode("utf-8"))
+    payload["tapdb"].update(
+        {
+            "config_path": str(tapdb_config_path),
+            "domain_registry_path": str(domain_registry_path),
+            "prefix_ownership_registry_path": str(prefix_registry_path),
+        }
     )
+    _write_config(config_path, "local", payload)
     tapdb_config_path.parent.mkdir(parents=True, exist_ok=True)
     tapdb_config_path.write_text("tapdb: {}\n", encoding="utf-8")
     monkeypatch.setenv("ZEBRA_DAY_CONFIG_PATH", str(config_path))

--- a/tests/test_deploy_contract.py
+++ b/tests/test_deploy_contract.py
@@ -82,7 +82,7 @@ def test_pyproject_owns_python_dependencies_and_console_scripts() -> None:
     assert "optional-dependencies" not in pyproject["project"]
     assert "cli-core-yo==2.1.1" in dependencies
     assert "daylily-auth-cognito==2.1.5" in dependencies
-    assert "daylily-tapdb==7.0.1" in dependencies
+    assert "daylily-tapdb==7.0.3" in dependencies
     assert "boto3>=1.26.0" in dependencies
     assert "awscli" in dependencies
     assert "bandit[toml]>=1.8.0" in dependencies

--- a/tests/test_gui_cli.py
+++ b/tests/test_gui_cli.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import yaml
 from typer.testing import CliRunner
 
 import zebra_day.cli as zebra_cli
 from zebra_day.cli import gui as gui_module
+from zebra_day.settings import build_default_config_template
 
 runner = CliRunner()
 
@@ -21,8 +23,17 @@ def _set_xdg(monkeypatch, tmp_path, deployment="local") -> None:
     monkeypatch.setenv("CONDA_PREFIX", str(tmp_path / "conda" / deployment))
 
 
+def _write_explicit_config(tmp_path, deployment: str = "local") -> None:
+    config_path = tmp_path / "config" / "zebra_day" / f"zebra-day-config-{deployment}.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = yaml.safe_load(build_default_config_template(deployment))
+    payload["tapdb"]["physical_database"] = f"tapdb_{deployment}"
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
 def test_gui_start_uses_shared_tls_contract(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path, deployment="jemtest")
+    _write_explicit_config(tmp_path, deployment="jemtest")
     cert_dir = tmp_path / "state" / "dayhoff" / "jemtest" / "certs"
     cert_dir.mkdir(parents=True, exist_ok=True)
     cert_file = cert_dir / "cert.pem"
@@ -90,7 +101,7 @@ def test_gui_start_uses_shared_tls_contract(monkeypatch, tmp_path):
     assert str(key_file) in calls["cmd"][2]
 
 
-def test_gui_start_supports_deprecated_no_https_alias(monkeypatch, tmp_path):
+def test_gui_start_rejects_removed_no_https_alias(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path)
 
     class _Process:
@@ -100,43 +111,10 @@ def test_gui_start_supports_deprecated_no_https_alias(monkeypatch, tmp_path):
         def poll():
             return None
 
-    monkeypatch.setattr(gui_module, "_ensure_runtime_ready", lambda *args, **kwargs: None)
-    monkeypatch.setattr(gui_module, "_running_pid", lambda *args, **kwargs: None)
-    monkeypatch.setattr(gui_module, "_log_file", lambda settings: tmp_path / "gui.log")
-    monkeypatch.setattr(gui_module, "_pid_file", lambda settings: tmp_path / "gui.pid")
-    monkeypatch.setattr(
-        gui_module, "_runtime_meta_file", lambda settings: tmp_path / "server-meta.json"
-    )
-    monkeypatch.setattr(
-        gui_module,
-        "resolve_https_certs",
-        lambda **kwargs: SimpleNamespace(
-            cert_path=tmp_path / "state" / "dayhoff" / "local" / "certs" / "cert.pem",
-            key_path=tmp_path / "state" / "dayhoff" / "local" / "certs" / "key.pem",
-            source="test",
-        ),
-    )
-    monkeypatch.setattr(
-        gui_module,
-        "shared_dayhoff_certs_dir",
-        lambda deployment_code: tmp_path / "state" / "dayhoff" / deployment_code / "certs",
-    )
-
-    def fake_popen(cmd, **kwargs):
-        return _Process()
-
-    monkeypatch.setattr(
-        gui_module,
-        "subprocess",
-        SimpleNamespace(
-            Popen=fake_popen, run=gui_module.subprocess.run, STDOUT=gui_module.subprocess.STDOUT
-        ),
-    )
-
     result = runner.invoke(zebra_cli.app, ["gui", "start", "--background", "--no-https"])
 
-    assert result.exit_code == 0
-    assert "http://localhost:8118" in result.output
+    assert result.exit_code != 0
+    assert "No such option" in result.output
 
 
 def test_gui_status_reads_runtime_meta(monkeypatch, tmp_path, capsys):

--- a/tests/test_modern_settings.py
+++ b/tests/test_modern_settings.py
@@ -7,7 +7,6 @@ import yaml
 
 from zebra_day import paths as xdg
 from zebra_day.settings import (
-    DEFAULT_DEPLOYMENT_BANNER_COLOR,
     ZebraDaySettings,
     _resolve_deployment_chrome,
     _stable_deployment_color_hex,
@@ -25,11 +24,24 @@ def _set_xdg(monkeypatch, tmp_path, deployment="stage-1") -> None:
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
     monkeypatch.setenv("ZEBRA_DAY_DEPLOYMENT_CODE", deployment)
+    monkeypatch.setenv("ZEBRA_DAY_SESSION_SECRET", f"test-secret-{deployment}")
     monkeypatch.setenv("CONDA_DEFAULT_ENV", f"ZEBRA_DAY-{deployment}")
     monkeypatch.delenv("ZEBRA_DAY_CONFIG_PATH", raising=False)
 
 
-def test_default_config_template_is_valid_yaml():
+def _default_payload(deployment: str) -> dict:
+    return yaml.safe_load(build_default_config_template(deployment).decode("utf-8"))
+
+
+def _write_config(path: Path, deployment: str, payload: dict | None = None) -> dict:
+    resolved = payload or _default_payload(deployment)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(resolved, sort_keys=False), encoding="utf-8")
+    return resolved
+
+
+def test_default_config_template_is_valid_yaml(monkeypatch):
+    monkeypatch.setenv("ZEBRA_DAY_SESSION_SECRET", "explicit-test-secret")
     content = build_default_config_template("dev").decode("utf-8")
     payload = yaml.safe_load(content)
     assert validate_settings_yaml(content) == []
@@ -54,6 +66,7 @@ def test_default_config_template_is_valid_yaml():
     assert payload["tapdb"]["domain_code"] == "Z"
     assert "env" not in payload["tapdb"]
     assert isinstance(payload["tapdb"]["config_path"], str) and payload["tapdb"]["config_path"]
+    assert payload["tapdb"]["physical_database"] == "tapdb_dev"
     assert isinstance(payload["tapdb"]["domain_registry_path"], str)
     assert isinstance(payload["tapdb"]["prefix_ownership_registry_path"], str)
     assert payload["ui"]["show_environment_chrome"] is True
@@ -72,16 +85,11 @@ def test_settings_from_context_uses_env_paths(monkeypatch, tmp_path):
     tapdb_config_path = tmp_path / "tapdb" / "zebra-day" / "zebra-day-qa-1" / "tapdb-config.yaml"
     domain_registry_path = tmp_path / "tapdb-registry" / "domain_code_registry.json"
     prefix_registry_path = tmp_path / "tapdb-registry" / "prefix_ownership_registry.json"
-    explicit_config.parent.mkdir(parents=True, exist_ok=True)
-    explicit_config.write_text(
-        (
-            "tapdb:\n"
-            f"  config_path: {tapdb_config_path}\n"
-            f"  domain_registry_path: {domain_registry_path}\n"
-            f"  prefix_ownership_registry_path: {prefix_registry_path}\n"
-        ),
-        encoding="utf-8",
-    )
+    payload = _default_payload("qa-1")
+    payload["tapdb"]["config_path"] = str(tapdb_config_path)
+    payload["tapdb"]["domain_registry_path"] = str(domain_registry_path)
+    payload["tapdb"]["prefix_ownership_registry_path"] = str(prefix_registry_path)
+    _write_config(explicit_config, "qa-1", payload)
 
     settings = ZebraDaySettings.from_context()
 
@@ -104,29 +112,27 @@ def test_settings_merge_file_values(monkeypatch, tmp_path):
     tapdb_config_path = tmp_path / "tapdb" / "tapdb-prod-custom.yaml"
     domain_registry_path = tmp_path / "tapdb-registry" / "domain_code_registry.json"
     prefix_registry_path = tmp_path / "tapdb-registry" / "prefix_ownership_registry.json"
-    config_path.write_text(
-        (
-            "service:\n"
-            "  host: localhost\n"
-            "  port: 8119\n"
-            "authentication:\n"
-            "  mode: none\n"
-            "  cognito_region: us-west-2\n"
-            "  cognito_user_pool_id: pool-123\n"
-            "  cognito_app_client_id: client-123\n"
-            "  cognito_domain: example.auth.us-west-2.amazoncognito.com\n"
-            "tapdb:\n"
-            "  client_id: zebra-day\n"
-            "  database_name: zebra-day-prod-custom\n"
-            f"  config_path: {tapdb_config_path}\n"
-            f"  domain_registry_path: {domain_registry_path}\n"
-            f"  prefix_ownership_registry_path: {prefix_registry_path}\n"
-            "deployment:\n"
-            "  name: sandbox-g\n"
-            "  color: '#123456'\n"
-        ),
-        encoding="utf-8",
+    payload = _default_payload("prodx")
+    payload["service"].update({"host": "localhost", "port": 8119})
+    payload["authentication"].update(
+        {
+            "mode": "none",
+            "cognito_region": "us-west-2",
+            "cognito_user_pool_id": "pool-123",
+            "cognito_app_client_id": "client-123",
+            "cognito_domain": "example.auth.us-west-2.amazoncognito.com",
+        }
     )
+    payload["tapdb"].update(
+        {
+            "database_name": "zebra-day-prod-custom",
+            "config_path": str(tapdb_config_path),
+            "domain_registry_path": str(domain_registry_path),
+            "prefix_ownership_registry_path": str(prefix_registry_path),
+        }
+    )
+    payload["deployment"].update({"name": "sandbox-g", "color": "#123456"})
+    _write_config(config_path, "prodx", payload)
 
     settings = ZebraDaySettings.from_context()
 
@@ -163,16 +169,16 @@ def test_settings_merge_file_values(monkeypatch, tmp_path):
 def test_settings_env_overrides_cognito_file_values(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path, deployment="prodx")
     config_path = xdg.get_config_file_path()
-    config_path.write_text(
-        (
-            "authentication:\n"
-            "  cognito_region: us-east-1\n"
-            "  cognito_user_pool_id: pool-file\n"
-            "  cognito_app_client_id: client-file\n"
-            "  cognito_domain: example.file.auth.us-west-2.amazoncognito.com\n"
-        ),
-        encoding="utf-8",
+    payload = _default_payload("prodx")
+    payload["authentication"].update(
+        {
+            "cognito_region": "us-east-1",
+            "cognito_user_pool_id": "pool-file",
+            "cognito_app_client_id": "client-file",
+            "cognito_domain": "example.file.auth.us-west-2.amazoncognito.com",
+        }
     )
+    _write_config(config_path, "prodx", payload)
     monkeypatch.setenv("COGNITO_REGION", "us-west-2")
     monkeypatch.setenv("COGNITO_USER_POOL_ID", "pool-env")
     monkeypatch.setenv("COGNITO_APP_CLIENT_ID", "client-env")
@@ -189,19 +195,18 @@ def test_settings_env_overrides_cognito_file_values(monkeypatch, tmp_path):
 def test_settings_accepts_external_broker_mode(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path, deployment="broker")
     config_path = xdg.get_config_file_path()
-    config_path.write_text(
-        (
-            "authentication:\n"
-            "  mode: external_broker\n"
-            "  external_broker:\n"
-            "    service_id: zebra-day\n"
-            "    login_url: https://dev.login.lsmc.com/auth/login\n"
-            "    handoff_exchange_url: https://dev.login.lsmc.com/auth/handoff/consume\n"
-            "    callback_url: https://localhost:8118/auth/lsmc/callback\n"
-            "    logout_url: https://dev.login.lsmc.com/auth/logout\n"
-        ),
-        encoding="utf-8",
+    payload = _default_payload("broker")
+    payload["authentication"]["mode"] = "external_broker"
+    payload["authentication"]["external_broker"].update(
+        {
+            "service_id": "zebra-day",
+            "login_url": "https://dev.login.lsmc.com/auth/login",
+            "handoff_exchange_url": "https://dev.login.lsmc.com/auth/handoff/consume",
+            "callback_url": "https://localhost:8118/auth/lsmc/callback",
+            "logout_url": "https://dev.login.lsmc.com/auth/logout",
+        }
     )
+    _write_config(config_path, "broker", payload)
 
     settings = ZebraDaySettings.from_context()
 
@@ -214,10 +219,9 @@ def test_settings_accepts_external_broker_mode(monkeypatch, tmp_path):
 def test_settings_rejects_schemeful_cognito_domain(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path, deployment="prodx")
     config_path = xdg.get_config_file_path()
-    config_path.write_text(
-        ("authentication:\n  cognito_domain: https://example.auth.us-west-2.amazoncognito.com\n"),
-        encoding="utf-8",
-    )
+    payload = _default_payload("prodx")
+    payload["authentication"]["cognito_domain"] = "https://example.auth.us-west-2.amazoncognito.com"
+    _write_config(config_path, "prodx", payload)
 
     with pytest.raises(ValueError, match="bare host"):
         ZebraDaySettings.from_context()
@@ -277,10 +281,9 @@ def test_validate_settings_yaml_requires_tapdb_registry_paths() -> None:
 def test_prod_deployment_name_hides_banner(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path, deployment="qa-1")
     config_path = xdg.get_config_file_path()
-    config_path.write_text(
-        "deployment:\n  name: production\n  color: ''\n",
-        encoding="utf-8",
-    )
+    payload = _default_payload("qa-1")
+    payload["deployment"].update({"name": "production", "color": ""})
+    _write_config(config_path, "qa-1", payload)
 
     settings = ZebraDaySettings.from_context()
 
@@ -291,12 +294,9 @@ def test_prod_deployment_name_hides_banner(monkeypatch, tmp_path):
     }
 
 
-def test_light_aqua_is_used_without_any_deployment_name():
-    assert _resolve_deployment_chrome(name="", color="", fallback_name="") == {
-        "name": "",
-        "color": DEFAULT_DEPLOYMENT_BANNER_COLOR,
-        "is_production": False,
-    }
+def test_deployment_chrome_requires_name_or_deployment_code():
+    with pytest.raises(ValueError, match="deployment.name is required"):
+        _resolve_deployment_chrome(name="", color="", deployment_code="")
 
 
 def test_repo_ships_tapdb_config_template():
@@ -304,17 +304,18 @@ def test_repo_ships_tapdb_config_template():
     payload = yaml.safe_load(template_path.read_text(encoding="utf-8"))
 
     assert template_path.is_file()
-    assert payload["meta"]["config_version"] == 3
+    assert payload["meta"]["config_version"] == 4
     assert payload["meta"]["client_id"] == "zebra-day"
-    assert payload["meta"]["database_name"] == "zebra-day"
+    assert payload["meta"]["database_name"] == "zebra-day-local"
     assert payload["meta"]["owner_repo_name"] == "zebra-day"
     assert payload["meta"]["domain_code"] == "Z"
     assert isinstance(payload["meta"]["domain_registry_path"], str)
     assert isinstance(payload["meta"]["prefix_registry_path"], str)
-    assert payload["environments"]["dev"]["port"] == "5544"
-    assert payload["environments"]["dev"]["database"] == "zebra_day_dev"
-    assert payload["environments"]["dev"]["audit_log_euid_prefix"] == "ZGX"
-    assert payload["environments"]["prod"]["audit_log_euid_prefix"] == "ZGX"
+    assert "environments" not in payload
+    assert payload["target"]["port"] == "5544"
+    assert payload["target"]["database"] == "tapdb_local"
+    assert payload["target"]["schema_name"] == "tapdb_zebra_day_local"
+    assert payload["target"]["audit_log_euid_prefix"] == "ZGX"
 
 
 def test_repo_ships_single_zebra_day_template_prefix():

--- a/tests/test_modern_web.py
+++ b/tests/test_modern_web.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from tests.fakes import sample_repository
 from zebra_day import __version__
 from zebra_day.client import ZebraDayClient
-from zebra_day.settings import ZebraDaySettings
+from zebra_day.settings import ZebraDaySettings, build_default_config_template
 from zebra_day.web.app import create_app
 from zebra_day.web.auth import SessionPrincipal, build_user_identity
 
@@ -22,6 +22,13 @@ def _set_xdg(monkeypatch, tmp_path, deployment="local") -> None:
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
     monkeypatch.setenv("ZEBRA_DAY_DEPLOYMENT_CODE", deployment)
+    monkeypatch.setenv("ZEBRA_DAY_SESSION_SECRET", f"test-secret-{deployment}")
+    config_path = tmp_path / "config" / "zebra_day" / f"zebra-day-config-{deployment}.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        build_default_config_template(deployment).decode("utf-8"),
+        encoding="utf-8",
+    )
 
 
 def _seed_client(tmp_path, monkeypatch, deployment="local") -> ZebraDayClient:

--- a/zebra_day/cli/config_extra.py
+++ b/zebra_day/cli/config_extra.py
@@ -81,9 +81,7 @@ def _status() -> None:
     ccyo_out.detail(f"Deployment: {settings.deployment_code}")
     ccyo_out.detail(f"Config: {settings.config_path}")
     ccyo_out.detail(f"TapDB config: {settings.tapdb_config_path}")
-    ccyo_out.detail(
-        f"TapDB namespace: {settings.tapdb_client_id}/{settings.tapdb_database_name}"
-    )
+    ccyo_out.detail(f"TapDB namespace: {settings.tapdb_client_id}/{settings.tapdb_database_name}")
     ccyo_out.detail(f"TapDB owner repo: {getattr(settings, 'tapdb_owner_repo_name', '')}")
     ccyo_out.detail(f"TapDB domain code: {getattr(settings, 'tapdb_domain_code', '')}")
     ccyo_out.detail(f"Auth mode: {settings.auth_mode}")

--- a/zebra_day/cli/env.py
+++ b/zebra_day/cli/env.py
@@ -89,13 +89,9 @@ def deactivate():
     project_root = _find_project_root()
 
     if project_root is None:
-        # Fallback: just tell them to run deactivate
-        ccyo_out.print_text(
-            Panel.fit(
-                "[cyan]source zebra_day_deactivate[/cyan]\n[dim]or[/dim]\n[cyan]deactivate[/cyan]",
-                title="Run one of these commands to deactivate",
-                border_style="yellow",
-            )
+        raise typer.BadParameter(
+            "zebra_day project root could not be resolved; run this command from a checkout "
+            "or deactivate the conda environment explicitly."
         )
     else:
         deactivate_script = project_root / "zebra_day_deactivate"

--- a/zebra_day/cli/gui.py
+++ b/zebra_day/cli/gui.py
@@ -48,7 +48,7 @@ class _ResolveHttpsCerts(Protocol):
         key_path: str | None,
         env: Mapping[str, str],
         shared_certs_dir: Path,
-        fallback_certs_dir: Path,
+        generate_if_missing: bool,
     ) -> _ResolvedCerts: ...
 
 
@@ -158,7 +158,7 @@ def _resolve_ssl(
         key_path=key,
         env=dict(os.environ),
         shared_certs_dir=shared_dayhoff_certs_dir(settings.deployment_code),
-        fallback_certs_dir=settings.config_dir / "certs",
+        generate_if_missing=False,
     )
     return str(resolved.cert_path), str(resolved.key_path), True
 
@@ -179,12 +179,6 @@ def start(
         help="Auth mode: cognito, external_broker, or none",
     ),
     ssl: bool = typer.Option(True, "--ssl/--no-ssl", help="Serve over HTTPS"),
-    no_https: bool = typer.Option(
-        False,
-        "--no-https",
-        help="Deprecated alias for --no-ssl",
-        hidden=True,
-    ),
     cert: str | None = typer.Option(None, "--cert", help="SSL certificate path"),
     key: str | None = typer.Option(None, "--key", help="SSL private key path"),
 ) -> None:
@@ -208,7 +202,7 @@ def start(
         ccyo_out.error(str(exc))
         raise typer.Exit(1) from exc
 
-    https_enabled = ssl and not no_https
+    https_enabled = ssl
     cert_path, key_path, https_enabled = _resolve_ssl(settings, cert, key, https_enabled)
     command = [
         sys.executable,

--- a/zebra_day/client.py
+++ b/zebra_day/client.py
@@ -338,7 +338,8 @@ class TapDBFleetRepository:
             db_pass=cfg["password"],
             db_name=cfg["database"],
             schema_name=cfg["schema_name"],
-            engine_type=str(cfg.get("engine_type") or "local"),
+            echo_sql=False,
+            engine_type=str(cfg["engine_type"]),
             domain_code=self.settings.tapdb_domain_code,
             owner_repo_name=self.settings.tapdb_owner_repo_name,
         )
@@ -598,7 +599,10 @@ class TapDBFleetRepository:
 
     def upsert_label_profile(self, profile_name: str, payload: dict[str, Any]) -> None:
         full_payload = dict(payload)
-        full_payload.setdefault("profile_name", profile_name)
+        provided_name = _clean(full_payload.get("profile_name"))
+        if provided_name and provided_name != profile_name:
+            raise ValueError("label profile payload profile_name must match request profile_name")
+        full_payload["profile_name"] = profile_name
         self._upsert_instance(
             template_code=LABEL_PROFILE_TEMPLATE_CODE,
             subtype="profile",

--- a/zebra_day/paths.py
+++ b/zebra_day/paths.py
@@ -3,22 +3,22 @@
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 
 APP_NAME = "zebra_day"
-DEFAULT_DEPLOYMENT_CODE = "local"
 
 
 def sanitize_deployment_code(value: str | None) -> str:
     """Normalize deployment names into safe path components."""
     raw = str(value or "").strip()
     if not raw:
-        return DEFAULT_DEPLOYMENT_CODE
+        raise RuntimeError("Zebra Day deployment code is required")
     sanitized = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "-" for ch in raw).strip(
         "-"
     )
-    return sanitized or DEFAULT_DEPLOYMENT_CODE
+    if not sanitized:
+        raise RuntimeError(f"Invalid Zebra Day deployment code: {value!r}")
+    return sanitized
 
 
 def get_deployment_code() -> str:
@@ -26,13 +26,8 @@ def get_deployment_code() -> str:
     explicit_deployment = os.environ.get("ZEBRA_DAY_DEPLOYMENT_CODE", "").strip()
     if explicit_deployment:
         return sanitize_deployment_code(explicit_deployment)
-    conda_default_env = os.environ.get("CONDA_DEFAULT_ENV", "").strip()
-    if conda_default_env.startswith("ZEBRA_DAY-"):
-        return sanitize_deployment_code(conda_default_env.removeprefix("ZEBRA_DAY-"))
     return sanitize_deployment_code(
-        os.environ.get("DEPLOYMENT_CODE")
-        or os.environ.get("LSMC_DEPLOYMENT_CODE")
-        or DEFAULT_DEPLOYMENT_CODE
+        os.environ.get("DEPLOYMENT_CODE") or os.environ.get("LSMC_DEPLOYMENT_CODE")
     )
 
 
@@ -46,14 +41,19 @@ def get_config_filename() -> str:
     return f"zebra-day-config-{get_deployment_code()}.yaml"
 
 
-def _get_xdg_dir(env_var: str, fallback: Path) -> Path:
+def _get_xdg_dir(env_var: str) -> Path:
     env_value = os.environ.get(env_var)
-    return Path(env_value) if env_value else fallback
+    if not env_value:
+        raise RuntimeError(f"{env_var} is required for Zebra Day runtime paths")
+    path = Path(env_value)
+    if not path.is_absolute():
+        raise RuntimeError(f"{env_var} must be an absolute path: {env_value}")
+    return path
 
 
 def get_config_dir() -> Path:
     """Return the shared zebra_day config directory."""
-    base = _get_xdg_dir("XDG_CONFIG_HOME", Path.home() / ".config")
+    base = _get_xdg_dir("XDG_CONFIG_HOME")
     config_dir = base / APP_NAME
     config_dir.mkdir(parents=True, exist_ok=True)
     return config_dir
@@ -67,14 +67,7 @@ def get_config_file_path() -> Path:
 def get_data_dir() -> Path:
     """Return the deployment-scoped data directory."""
     deployment = get_deployment_code()
-    if sys.platform == "darwin":
-        fallback = Path.home() / "Library" / "Application Support" / APP_NAME / deployment
-    else:
-        fallback = Path.home() / ".local" / "share" / APP_NAME / deployment
-    if sys.platform == "darwin":
-        base = _get_xdg_dir("XDG_DATA_HOME", fallback.parent.parent)
-    else:
-        base = _get_xdg_dir("XDG_DATA_HOME", fallback.parent.parent)
+    base = _get_xdg_dir("XDG_DATA_HOME")
     data_dir = base / APP_NAME / deployment
     data_dir.mkdir(parents=True, exist_ok=True)
     return data_dir
@@ -83,12 +76,7 @@ def get_data_dir() -> Path:
 def get_state_dir() -> Path:
     """Return the deployment-scoped state directory."""
     deployment = get_deployment_code()
-    if sys.platform == "darwin":
-        fallback = Path.home() / "Library" / "Logs" / APP_NAME / deployment
-        base = _get_xdg_dir("XDG_STATE_HOME", fallback.parent.parent)
-    else:
-        fallback = Path.home() / ".local" / "state" / APP_NAME / deployment
-        base = _get_xdg_dir("XDG_STATE_HOME", fallback.parent.parent)
+    base = _get_xdg_dir("XDG_STATE_HOME")
     state_dir = base / APP_NAME / deployment
     state_dir.mkdir(parents=True, exist_ok=True)
     return state_dir
@@ -97,12 +85,7 @@ def get_state_dir() -> Path:
 def get_cache_dir() -> Path:
     """Return the deployment-scoped cache directory."""
     deployment = get_deployment_code()
-    if sys.platform == "darwin":
-        fallback = Path.home() / "Library" / "Caches" / APP_NAME / deployment
-        base = _get_xdg_dir("XDG_CACHE_HOME", fallback.parent.parent)
-    else:
-        fallback = Path.home() / ".cache" / APP_NAME / deployment
-        base = _get_xdg_dir("XDG_CACHE_HOME", fallback.parent.parent)
+    base = _get_xdg_dir("XDG_CACHE_HOME")
     cache_dir = base / APP_NAME / deployment
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir

--- a/zebra_day/settings.py
+++ b/zebra_day/settings.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import colorsys
 import hashlib
 import os
-import secrets
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -43,9 +42,10 @@ DEFAULT_ALLOWED_EMAIL_DOMAINS = [
     "daylilyinformatics.com",
 ]
 ZERO_TENANT_ID = "00000000-0000-0000-0000-000000000000"
-_DEFAULT_SESSION_SECRET_KEY = os.environ.get("ZEBRA_DAY_SESSION_SECRET") or secrets.token_urlsafe(
-    64
-)
+
+
+def _default_session_secret_key() -> str:
+    return os.environ.get("ZEBRA_DAY_SESSION_SECRET", "").strip()
 
 
 def _normalize_string_list(value: Any) -> list[str]:
@@ -60,9 +60,11 @@ def _normalize_string_list(value: Any) -> list[str]:
 
 def _load_yaml(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {}
-    content = yaml.safe_load(path.read_text()) or {}
-    return content if isinstance(content, dict) else {}
+        raise ValueError(f"Zebra Day config file is required: {path}")
+    content = yaml.safe_load(path.read_text())
+    if not isinstance(content, dict):
+        raise ValueError(f"Zebra Day config root must be a YAML mapping: {path}")
+    return content
 
 
 def _validate_cognito_domain(value: Any) -> str:
@@ -85,16 +87,14 @@ def _resolve_deployment_chrome(
     *,
     name: str | None,
     color: str | None,
-    fallback_name: str | None = None,
+    deployment_code: str | None = None,
 ) -> dict[str, object]:
-    resolved_name = str(name or "").strip() or str(fallback_name or "").strip()
+    resolved_name = str(name or "").strip() or str(deployment_code or "").strip()
+    if not resolved_name:
+        raise ValueError("deployment.name is required")
     resolved_color = str(color or "").strip()
     if not resolved_color:
-        resolved_color = (
-            _stable_deployment_color_hex(resolved_name)
-            if resolved_name
-            else DEFAULT_DEPLOYMENT_BANNER_COLOR
-        )
+        resolved_color = _stable_deployment_color_hex(resolved_name)
     return {
         "name": resolved_name,
         "color": resolved_color,
@@ -116,7 +116,7 @@ def build_default_config_template(deployment: str | None = None) -> bytes:
             "mode": DEFAULT_AUTH_MODE,
             "internal_api_key_env": "INTERNAL_API_KEY",
             "session_cookie_name": "zebra_day_session",
-            "session_secret_key": _DEFAULT_SESSION_SECRET_KEY,
+            "session_secret_key": _default_session_secret_key(),
             "callback_path": "/auth/callback",
             "logout_path": "/auth/logout",
             "external_broker": {
@@ -141,7 +141,7 @@ def build_default_config_template(deployment: str | None = None) -> bytes:
             "domain_code": DEFAULT_MERIDIAN_DOMAIN_CODE,
             "database_name": f"{DEFAULT_TAPDB_CLIENT_ID}-{deployment_code}",
             "schema_name": f"tapdb_zebra_day_{deployment_code.replace('-', '_')}",
-            "physical_database": "",
+            "physical_database": f"tapdb_{deployment_code.replace('-', '_')}",
             "local_db_port": DEFAULT_TAPDB_LOCAL_DB_PORT,
             "local_ui_port": DEFAULT_TAPDB_LOCAL_UI_PORT,
             "config_path": str(
@@ -175,7 +175,7 @@ def build_default_config_template(deployment: str | None = None) -> bytes:
 def validate_settings_yaml(content: str) -> list[str]:
     """Validate deployment-scoped zebra_day config."""
     try:
-        config = yaml.safe_load(content) or {}
+        config = yaml.safe_load(content)
     except yaml.YAMLError as exc:
         return [f"YAML parse error: {exc}"]
 
@@ -312,14 +312,10 @@ class ZebraDaySettings:
     def from_context(cls, deployment: str | None = None) -> ZebraDaySettings:
         deployment_code = xdg.sanitize_deployment_code(deployment or xdg.get_deployment_code())
         config_path = Path(os.environ.get("ZEBRA_DAY_CONFIG_PATH") or xdg.get_config_file_path())
-        merged = yaml.safe_load(build_default_config_template(deployment_code)) or {}
-        file_payload = _load_yaml(config_path)
-
+        merged = _load_yaml(config_path)
         for section in ("service", "authentication", "tapdb", "discovery", "deployment", "ui"):
-            file_section = file_payload.get(section)
-            if isinstance(file_section, dict):
-                merged.setdefault(section, {})
-                merged[section].update(file_section)
+            if not isinstance(merged.get(section), dict):
+                raise ValueError(f"Zebra Day config section {section!r} is required")
 
         service = merged.get("service") or {}
         auth = merged.get("authentication") or {}
@@ -335,21 +331,33 @@ class ZebraDaySettings:
             color=(merged.get("deployment") or {}).get("color")
             if isinstance(merged.get("deployment"), dict)
             else "",
-            fallback_name=deployment_code,
+            deployment_code=deployment_code,
         )
 
-        client_id = str(tapdb.get("client_id") or DEFAULT_TAPDB_CLIENT_ID).strip()
-        owner_repo_name = str(tapdb.get("owner_repo_name") or DEFAULT_TAPDB_OWNER_REPO).strip()
-        domain_code = str(tapdb.get("domain_code") or DEFAULT_MERIDIAN_DOMAIN_CODE).strip()
-        database_name = str(
-            tapdb.get("database_name") or f"{DEFAULT_TAPDB_CLIENT_ID}-{deployment_code}"
-        ).strip()
+        client_id = str(tapdb.get("client_id") or "").strip()
+        if not client_id:
+            raise ValueError("tapdb.client_id is required")
+        owner_repo_name = str(tapdb.get("owner_repo_name") or "").strip()
+        if not owner_repo_name:
+            raise ValueError("tapdb.owner_repo_name is required")
+        domain_code = str(tapdb.get("domain_code") or "").strip()
+        if not domain_code:
+            raise ValueError("tapdb.domain_code is required")
+        database_name = str(tapdb.get("database_name") or "").strip()
+        if not database_name:
+            raise ValueError("tapdb.database_name is required")
         schema_name = str(tapdb.get("schema_name") or "").strip()
         if not schema_name:
             raise ValueError("tapdb.schema_name is required")
         physical_database = str(tapdb.get("physical_database") or "").strip()
-        local_db_port = int(tapdb.get("local_db_port") or DEFAULT_TAPDB_LOCAL_DB_PORT)
-        local_ui_port = int(tapdb.get("local_ui_port") or DEFAULT_TAPDB_LOCAL_UI_PORT)
+        if not physical_database:
+            raise ValueError("tapdb.physical_database is required")
+        if tapdb.get("local_db_port") in (None, ""):
+            raise ValueError("tapdb.local_db_port is required")
+        if tapdb.get("local_ui_port") in (None, ""):
+            raise ValueError("tapdb.local_ui_port is required")
+        local_db_port = int(str(tapdb["local_db_port"]).strip())
+        local_ui_port = int(str(tapdb["local_ui_port"]).strip())
         tapdb_config_value = str(tapdb.get("config_path") or "").strip()
         if not tapdb_config_value:
             raise ValueError("tapdb.config_path is required")
@@ -391,9 +399,7 @@ class ZebraDaySettings:
             internal_api_key=str(
                 os.environ.get(str(auth.get("internal_api_key_env") or "INTERNAL_API_KEY")) or ""
             ).strip(),
-            session_secret_key=str(
-                auth.get("session_secret_key") or _DEFAULT_SESSION_SECRET_KEY
-            ).strip(),
+            session_secret_key=str(auth.get("session_secret_key") or "").strip(),
             session_cookie_name=str(auth.get("session_cookie_name") or "zebra_day_session"),
             allowed_email_domains=_normalize_string_list(
                 auth.get("allowed_email_domains") or DEFAULT_ALLOWED_EMAIL_DOMAINS
@@ -475,7 +481,7 @@ class ZebraDaySettings:
                 auth.get("group_role_map") or DEFAULT_COGNITO_GROUP_ROLE_MAP
             )
             or dict(DEFAULT_COGNITO_GROUP_ROLE_MAP),
-            default_scan_wait_seconds=float(discovery.get("default_scan_wait_seconds") or 0.5),
+            default_scan_wait_seconds=float(discovery["default_scan_wait_seconds"]),
             default_http_port=(
                 int(discovery["default_http_port"])
                 if discovery.get("default_http_port") not in (None, "")

--- a/zebra_day/web/auth.py
+++ b/zebra_day/web/auth.py
@@ -183,11 +183,7 @@ def build_external_broker_identity(
         )
     groups = [str(group).strip() for group in user.get("groups") or [] if str(group).strip()]
     service_id = _clean(settings.external_broker_service_id) or "zebra-day"
-    roles = {
-        str(role).strip().upper()
-        for role in user.get("roles") or []
-        if str(role).strip()
-    }
+    roles = {str(role).strip().upper() for role in user.get("roles") or [] if str(role).strip()}
     if "lsmc:global-admin" in groups or f"lsmc:{service_id}:admin" in groups:
         roles.add("ADMIN")
     for entitlement in user.get("service_entitlements") or []:
@@ -247,13 +243,10 @@ def _daycog_config_path() -> Path:
 def _load_daycog_file_values() -> dict[str, str]:
     path = _daycog_config_path()
     if not path.exists():
-        return {}
-    try:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return {}
+        raise RuntimeError(f"daycog config store is required: {path}")
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
-        return {}
+        raise RuntimeError(f"daycog config store must be a YAML mapping: {path}")
     return {str(key): str(value) for key, value in payload.items() if value is not None}
 
 
@@ -614,27 +607,6 @@ class CognitoBinding:
             raise ValueError("Invalid Cognito id token") from exc
         return dict(claims)
 
-    def _decode_id_token_unverified(self, id_token: str) -> dict[str, Any]:
-        from jose import JWTError, jwt
-
-        try:
-            claims = jwt.decode(
-                id_token,
-                key="",
-                options={
-                    "verify_signature": False,
-                    "verify_exp": False,
-                    "verify_iss": False,
-                    "verify_aud": False,
-                    "verify_nbf": False,
-                    "verify_iat": False,
-                    "verify_at_hash": False,
-                },
-            )
-        except JWTError as exc:
-            raise ValueError("Invalid Cognito id token payload") from exc
-        return dict(claims)
-
     def exchange_code(self, request: Request, code: str) -> dict[str, Any]:
         tokens = _run_sync(
             cognito_session.exchange_authorization_code_async(
@@ -652,20 +624,7 @@ class CognitoBinding:
         profile_claims: dict[str, Any] = {}
         id_token = _clean(tokens.get("id_token"))
         if id_token:
-            try:
-                profile_claims = self._verify_id_token(id_token, access_token=access_token)
-            except ValueError as exc:
-                _log.warning(
-                    "Falling back to unverified Cognito id token decode for profile claims: %s",
-                    exc,
-                )
-                try:
-                    profile_claims = self._decode_id_token_unverified(id_token)
-                except ValueError as decode_exc:
-                    _log.warning(
-                        "Continuing without Cognito id token profile claims: %s",
-                        decode_exc,
-                    )
+            profile_claims = self._verify_id_token(id_token, access_token=access_token)
         return {"tokens": tokens, "claims": claims, "profile_claims": profile_claims}
 
     def resolve_principal(
@@ -679,21 +638,7 @@ class CognitoBinding:
         profile_claims: dict[str, Any] = {}
         id_token = _clean(token_payload.get("id_token"))
         if id_token:
-            try:
-                profile_claims = self._verify_id_token(id_token, access_token=access_token)
-            except ValueError as exc:
-                _log.warning(
-                    "Falling back to unverified Cognito id token decode for profile claims: %s",
-                    exc,
-                )
-                try:
-                    profile_claims = self._decode_id_token_unverified(id_token)
-                except ValueError as decode_exc:
-                    _log.warning(
-                        "Continuing without Cognito id token profile claims: %s",
-                        decode_exc,
-                    )
-                    profile_claims = {}
+            profile_claims = self._verify_id_token(id_token, access_token=access_token)
 
         merged_claims = dict(claims)
         for key, value in profile_claims.items():

--- a/zebra_day/zpl_renderer.py
+++ b/zebra_day/zpl_renderer.py
@@ -75,18 +75,13 @@ class RenderState:
 
 
 def _get_font(height: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
-    """Get a font at the specified height. Falls back to default if unavailable."""
-    try:
-        # Try common monospace fonts
-        for font_name in ["DejaVuSansMono.ttf", "Menlo.ttc", "Courier New.ttf", "monospace"]:
-            try:
-                return ImageFont.truetype(font_name, height)
-            except OSError:
-                continue
-        # Fallback to default
-        return ImageFont.load_default()
-    except Exception:
-        return ImageFont.load_default()
+    """Get a configured local monospace font at the specified height."""
+    for font_name in ["DejaVuSansMono.ttf", "Menlo.ttc", "Courier New.ttf", "monospace"]:
+        try:
+            return ImageFont.truetype(font_name, height)
+        except OSError:
+            continue
+    raise RuntimeError("No supported monospace font is available for Zebra Day rendering")
 
 
 def _render_barcode(


### PR DESCRIPTION
## Summary

- Updates Zebra Day to `daylily-tapdb==7.0.3` and explicit-target TapDB config.
- Keeps runtime config strict: missing deployment/config/TapDB settings fail instead of being inferred.
- Removes stale legacy package data and updates auth/settings/tests for the no-fallback login cutover.

## Validation

- `ZEBRA_DAY_DEPLOYMENT_CODE=unidbtst ruff check zebra_day tests`
- `ZEBRA_DAY_DEPLOYMENT_CODE=unidbtst mypy zebra_day`
- `ZEBRA_DAY_DEPLOYMENT_CODE=unidbtst pytest -q tests/test_packaging_metadata.py tests/test_deploy_contract.py tests/test_client_runtime.py tests/test_auth.py tests/test_cli_extended.py tests/test_gui_cli.py tests/test_modern_settings.py tests/test_modern_web.py`