### PR TITLE
Fix external broker session hostname

### DIFF
--- a/tests/test_modern_web.py
+++ b/tests/test_modern_web.py
@@ -521,12 +521,18 @@ def test_auth_login_redirects_to_cognito_hosted_ui(tmp_path, monkeypatch):
 
 def test_external_broker_login_and_callback_create_session(tmp_path, monkeypatch):
     monkeypatch.setenv("LSMC_AUTH_BROKER_SERVICE_ID", "zebra-day")
-    monkeypatch.setenv("LSMC_AUTH_BROKER_LOGIN_URL", "https://dev.login.lsmc.com/auth/login")
+    monkeypatch.setenv(
+        "LSMC_AUTH_BROKER_LOGIN_URL",
+        "https://dev.login.lsmc.com:8916/auth/login",
+    )
     monkeypatch.setenv(
         "LSMC_AUTH_BROKER_HANDOFF_EXCHANGE_URL",
-        "https://dev.login.lsmc.com/auth/handoff/consume",
+        "https://dev.login.lsmc.com:8916/auth/handoff/consume",
     )
-    monkeypatch.setenv("LSMC_AUTH_BROKER_LOGOUT_URL", "https://dev.login.lsmc.com/auth/logout")
+    monkeypatch.setenv(
+        "LSMC_AUTH_BROKER_LOGOUT_URL",
+        "https://dev.login.lsmc.com:8916/auth/logout",
+    )
 
     class FakeResponse:
         status_code = 200
@@ -554,7 +560,7 @@ def test_external_broker_login_and_callback_create_session(tmp_path, monkeypatch
             return None
 
         async def post(self, url, json):
-            assert url == "https://dev.login.lsmc.com/auth/handoff/consume"
+            assert url == "https://dev.login.lsmc.com:8916/auth/handoff/consume"
             assert json == {"code": "handoff-code"}
             return FakeResponse()
 
@@ -569,7 +575,7 @@ def test_external_broker_login_and_callback_create_session(tmp_path, monkeypatch
         assert login.status_code == 302
         login_url = urlparse(login.headers["location"])
         assert f"{login_url.scheme}://{login_url.netloc}{login_url.path}" == (
-            "https://dev.login.lsmc.com/auth/login"
+            "https://dev.login.lsmc.com:8916/auth/login"
         )
         query = parse_qs(login_url.query)
         assert query["service"] == ["zebra-day"]

--- a/zebra_day/web/auth.py
+++ b/zebra_day/web/auth.py
@@ -394,7 +394,10 @@ def build_web_session_config(settings: ZebraDaySettings) -> CognitoWebSessionCon
         client_id = settings.cognito_app_client_id
     elif settings.auth_mode == "external_broker":
         _require_external_broker_runtime_settings(settings)
-        domain = urlsplit(settings.external_broker_login_url).netloc
+        domain = _required_url_hostname(
+            settings.external_broker_login_url,
+            field_name="LSMC_AUTH_BROKER_LOGIN_URL",
+        )
         client_id = settings.external_broker_service_id
     else:
         domain = _clean(settings.cognito_domain) or "localhost"
@@ -412,6 +415,13 @@ def build_web_session_config(settings: ZebraDaySettings) -> CognitoWebSessionCon
         allow_insecure_http=public_base_url.startswith("http://"),
         auth_mode=settings.auth_mode,
     )
+
+
+def _required_url_hostname(value: str, *, field_name: str) -> str:
+    parsed = urlsplit(str(value or "").strip())
+    if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+        raise ValueError(f"{field_name} must be an absolute URL with host")
+    return parsed.hostname
 
 
 def start_external_broker_login(


### PR DESCRIPTION
Fixes external broker browser sessions when the broker URL includes a port by passing only the parsed hostname to the Cognito web-session domain field.\n\nTests:\n- pytest tests/test_modern_web.py -q\n- ruff check zebra_day/web/auth.py tests/test_modern_web.py