### PR TITLE
Pass TapDB app username

### DIFF
--- a/tests/test_client_runtime.py
+++ b/tests/test_client_runtime.py
@@ -106,6 +106,7 @@ def test_tapdb_fleet_repository_builds_connection_with_zebra_scope(monkeypatch, 
     assert captured["domain_code"] == DEFAULT_MERIDIAN_DOMAIN_CODE
     assert captured["owner_repo_name"] == DEFAULT_TAPDB_OWNER_REPO
     assert captured["schema_name"] == settings.tapdb_schema_name
+    assert captured["app_username"] == settings.tapdb_client_id
     assert "domain_registry_path" not in captured
     assert "prefix_registry_path" not in captured
 

--- a/zebra_day/client.py
+++ b/zebra_day/client.py
@@ -333,6 +333,7 @@ class TapDBFleetRepository:
         )
         db_hostname = f"{cfg['host']}:{cfg['port']}"
         return tapdb_mod.TAPDBConnection(
+            app_username=self.settings.tapdb_client_id,
             db_hostname=db_hostname,
             db_user=cfg["user"],
             db_pass=cfg["password"],


### PR DESCRIPTION
## Summary
- pass the explicit Zebra Day TapDB client id as app_username when building TAPDBConnection
- add focused regression coverage

## Tests
- source ./activate unidbtst >/tmp/zebra_activate.log && python -m py_compile zebra_day/client.py tests/test_client_runtime.py && pytest tests/test_client_runtime.py::test_tapdb_fleet_repository_builds_connection_with_zebra_scope -q && ruff check zebra_day/client.py tests/test_client_runtime.py