### PR TITLE
Honor configured GUI auth mode

### DIFF
--- a/tests/test_gui_cli.py
+++ b/tests/test_gui_cli.py
@@ -101,6 +101,66 @@ def test_gui_start_uses_shared_tls_contract(monkeypatch, tmp_path):
     assert str(key_file) in calls["cmd"][2]
 
 
+def test_gui_start_uses_configured_auth_mode_when_auth_option_omitted(monkeypatch, tmp_path):
+    _set_xdg(monkeypatch, tmp_path, deployment="broker")
+    config_path = tmp_path / "config" / "zebra_day" / "zebra-day-config-broker.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = yaml.safe_load(build_default_config_template("broker"))
+    payload["tapdb"]["physical_database"] = "tapdb_broker"
+    payload["authentication"]["mode"] = "external_broker"
+    payload["authentication"]["external_broker"].update(
+        {
+            "service_id": "zebra-day",
+            "login_url": "https://localhost:8916/auth/login",
+            "handoff_exchange_url": "https://localhost:8916/auth/handoff/consume",
+            "callback_url": "https://localhost:8118/auth/lsmc/callback",
+            "logout_url": "https://localhost:8916/auth/logout",
+        }
+    )
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    calls: dict[str, object] = {}
+
+    class _Process:
+        pid = 65432
+
+        @staticmethod
+        def poll():
+            return None
+
+    def _ensure_runtime_ready(settings, selected_auth):
+        calls["selected_auth"] = selected_auth
+
+    def fake_popen(cmd, **kwargs):
+        calls["cmd"] = cmd
+        calls["env"] = kwargs["env"]
+        return _Process()
+
+    monkeypatch.setattr(gui_module, "_ensure_runtime_ready", _ensure_runtime_ready)
+    monkeypatch.setattr(gui_module, "_running_pid", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gui_module, "_log_file", lambda settings: tmp_path / "gui.log")
+    monkeypatch.setattr(gui_module, "_pid_file", lambda settings: tmp_path / "gui.pid")
+    monkeypatch.setattr(
+        gui_module,
+        "_runtime_meta_file",
+        lambda settings: tmp_path / "server-meta.json",
+    )
+    monkeypatch.setattr(
+        gui_module,
+        "subprocess",
+        SimpleNamespace(
+            Popen=fake_popen, run=gui_module.subprocess.run, STDOUT=gui_module.subprocess.STDOUT
+        ),
+    )
+
+    result = runner.invoke(zebra_cli.app, ["gui", "start", "--background", "--no-ssl"])
+
+    assert result.exit_code == 0
+    assert calls["selected_auth"] == "external_broker"
+    assert "auth='external_broker'" in calls["cmd"][2]
+    assert calls["env"]["ZEBRA_DAY_AUTH_MODE"] == "external_broker"
+
+
 def test_gui_start_rejects_removed_no_https_alias(monkeypatch, tmp_path):
     _set_xdg(monkeypatch, tmp_path)
 

--- a/zebra_day/cli/gui.py
+++ b/zebra_day/cli/gui.py
@@ -173,10 +173,10 @@ def start(
         help="Run in background or foreground",
     ),
     reload: bool = typer.Option(False, "--reload", help="Enable auto reload"),
-    auth: str = typer.Option(
-        "cognito",
+    auth: str | None = typer.Option(
+        None,
         "--auth",
-        help="Auth mode: cognito, external_broker, or none",
+        help="Auth mode override: cognito, external_broker, or none. Omit to use the configured mode.",
     ),
     ssl: bool = typer.Option(True, "--ssl/--no-ssl", help="Serve over HTTPS"),
     cert: str | None = typer.Option(None, "--cert", help="SSL certificate path"),
@@ -186,7 +186,7 @@ def start(
     settings = ZebraDaySettings.from_context()
     settings.logs_dir.mkdir(parents=True, exist_ok=True)
     settings.state_dir.mkdir(parents=True, exist_ok=True)
-    selected_auth = "none" if settings.auth_mode == "none" else auth
+    selected_auth = str(auth or settings.auth_mode).strip()
     if selected_auth not in {"none", "cognito", "external_broker"}:
         ccyo_out.error("auth must be 'cognito', 'external_broker', or 'none'")
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary
- make zday gui start use the configured authentication.mode when --auth is omitted
- preserve explicit --auth as an override
- add regression coverage for external_broker config-driven startup

## Tests
- source ./activate unidbtst >/tmp/zebra_activate.log && ZEBRA_DAY_DEPLOYMENT_CODE=unidbtst python -m py_compile zebra_day/cli/gui.py tests/test_gui_cli.py && ZEBRA_DAY_DEPLOYMENT_CODE=unidbtst pytest tests/test_gui_cli.py::test_gui_start_uses_configured_auth_mode_when_auth_option_omitted tests/test_gui_cli.py::test_gui_start_uses_shared_tls_contract -q && ZEBRA_DAY_DEPLOYMENT_CODE=unidbtst ruff check --select F zebra_day/cli/gui.py tests/test_gui_cli.py