### PR TITLE
[codex] Require explicit broker CA for external auth

### DIFF
--- a/tests/test_modern_web.py
+++ b/tests/test_modern_web.py
@@ -550,8 +550,9 @@ def test_external_broker_login_and_callback_create_session(tmp_path, monkeypatch
             }
 
     class FakeAsyncClient:
-        def __init__(self, *, timeout):
+        def __init__(self, *, timeout, verify):
             self.timeout = timeout
+            self.verify = verify
 
         async def __aenter__(self):
             return self

--- a/zebra_day/settings.py
+++ b/zebra_day/settings.py
@@ -125,6 +125,7 @@ def build_default_config_template(deployment: str | None = None) -> bytes:
                 "handoff_exchange_url": "",
                 "callback_url": "",
                 "logout_url": "",
+                "ca_bundle": "",
             },
             "cognito_region": "",
             "cognito_user_pool_id": "",
@@ -283,6 +284,7 @@ class ZebraDaySettings:
     external_broker_handoff_exchange_url: str
     external_broker_callback_url: str
     external_broker_logout_url: str
+    external_broker_ca_bundle: str
     tapdb_client_id: str
     tapdb_owner_repo_name: str
     tapdb_domain_code: str
@@ -299,6 +301,11 @@ class ZebraDaySettings:
     cognito_group_role_map: dict[str, str]
     default_scan_wait_seconds: float
     default_http_port: int | None
+
+    def __post_init__(self) -> None:
+        ca_bundle = str(self.external_broker_ca_bundle or "").strip()
+        if ca_bundle and not Path(ca_bundle).is_file():
+            raise ValueError("authentication.external_broker.ca_bundle does not exist")
 
     @property
     def deployment(self) -> dict[str, object]:
@@ -462,6 +469,12 @@ class ZebraDaySettings:
                 os.environ.get("LSMC_AUTH_BROKER_LOGOUT_URL")
                 or os.environ.get("ZEBRA_DAY_EXTERNAL_BROKER_LOGOUT_URL")
                 or auth_external_broker.get("logout_url")
+                or ""
+            ).strip(),
+            external_broker_ca_bundle=str(
+                os.environ.get("LSMC_AUTH_BROKER_CA_BUNDLE")
+                or os.environ.get("ZEBRA_DAY_EXTERNAL_BROKER_CA_BUNDLE")
+                or auth_external_broker.get("ca_bundle")
                 or ""
             ).strip(),
             tapdb_client_id=client_id,

--- a/zebra_day/web/auth.py
+++ b/zebra_day/web/auth.py
@@ -466,7 +466,9 @@ async def complete_external_broker_callback(
     expected_state = _clean(request.session.get(EXTERNAL_BROKER_STATE_KEY))
     if not expected_state or state != expected_state:
         raise CognitoWebAuthError("invalid_state", "External broker state mismatch")
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    ca_bundle = _clean(settings.external_broker_ca_bundle)
+    verify: bool | str = ca_bundle if ca_bundle else True
+    async with httpx.AsyncClient(timeout=10.0, verify=verify) as client:
         response = await client.post(
             settings.external_broker_handoff_exchange_url,
             json={"code": code},


### PR DESCRIPTION
## Summary
- add explicit external broker CA bundle configuration
- use that CA bundle for broker handoff exchange requests
- update broker callback test doubles for the explicit TLS verify contract

## Checks
- `source ./activate unidbtst && pytest -q tests/test_modern_settings.py tests/test_modern_web.py` -> 39 passed
- `git diff --check`
- `python -m py_compile zebra_day/settings.py zebra_day/web/auth.py tests/test_modern_web.py`
